### PR TITLE
:heavy_plus_sign: chore: add Notion and GitHub PR sync

### DIFF
--- a/.github/workflows/call-notion-sync.yml
+++ b/.github/workflows/call-notion-sync.yml
@@ -1,0 +1,13 @@
+# .github/workflows/call-notion-sync.yml (사용하는 쪽 레포)
+name: Call Notion Sync
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+jobs:
+  call-notion-sync:
+    uses: Beyond-Imagination/github-actions/.github/workflows/sync-pr-to-notion.yml@main
+    secrets:
+      NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+      NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}


### PR DESCRIPTION
## 📝작업 내용
깃허브 pr과 노션 연동했습니다.
이제 pr을 open하면, 자동으로 id가 BOOKLINK-13인 이슈가 진행중으로 바뀌고, 해당 PR 링크가 추가됩니다.
pr을 main에 merge하면, 자동으로 진행사항이 완료로 바뀝니다.

### 참고자료
<img width="586" height="261" alt="image" src="https://github.com/user-attachments/assets/a61e094e-8ec6-4ec1-b684-90d266d634a2" />
