### PR TITLE
:recycle: refactor: Swagger 어노테이션 인터페이스로 분리, 예외 예시 구체화 적용

### DIFF
--- a/src/main/java/com/bookbook/booklink/common/exception/ApiErrorResponseCustomizer.java
+++ b/src/main/java/com/bookbook/booklink/common/exception/ApiErrorResponseCustomizer.java
@@ -1,0 +1,65 @@
+package com.bookbook.booklink.common.exception;
+
+import com.bookbook.booklink.common.exception.ErrorCode;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+import java.time.LocalDateTime;
+
+@Component
+public class ApiErrorResponseCustomizer implements OperationCustomizer {
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        ApiErrorResponses annotation = handlerMethod.getMethodAnnotation(ApiErrorResponses.class);
+        if (annotation == null) return operation;
+
+        ApiResponses apiResponses = operation.getResponses();
+
+        for (ErrorCode errorCode : annotation.value()) {
+            String statusCode = String.valueOf(errorCode.getHttpStatus().value());
+
+            // 이미 등록된 ApiResponse 가져오기 (없으면 새로 생성)
+            ApiResponse apiResponse = apiResponses.get(statusCode);
+            if (apiResponse == null) {
+                apiResponse = new ApiResponse()
+                        .description(errorCode.getHttpStatus().getReasonPhrase()) // "Bad Request", "Internal Server Error" 등
+                        .content(new Content().addMediaType("application/json", new MediaType()));
+                apiResponses.addApiResponse(statusCode, apiResponse);
+            }
+
+            // MediaType 안에 examples 추가
+            MediaType mediaType = apiResponse.getContent().get("application/json");
+            mediaType.addExamples(
+                    errorCode.name(), // enum 이름을 키로
+                    new Example().value("""
+                    {
+                      "success": false,
+                      "data": null,
+                      "error": {
+                        "timestamp": "2025-09-20T07:54:27.043Z",
+                        "status": %d,
+                        "code": "%s",
+                        "message": "%s",
+                        "path": "/api/..."
+                      }
+                    }
+                    """.formatted(
+                            errorCode.getHttpStatus().value(),
+                            errorCode.getCode(),
+                            errorCode.getMessage()
+                    ))
+            );
+        }
+
+
+        return operation;
+    }
+}

--- a/src/main/java/com/bookbook/booklink/common/exception/ApiErrorResponses.java
+++ b/src/main/java/com/bookbook/booklink/common/exception/ApiErrorResponses.java
@@ -1,0 +1,11 @@
+package com.bookbook.booklink.common.exception;
+
+import com.bookbook.booklink.common.exception.ErrorCode;
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ApiErrorResponses {
+    ErrorCode[] value();
+}

--- a/src/main/java/com/bookbook/booklink/common/exception/BaseResponse.java
+++ b/src/main/java/com/bookbook/booklink/common/exception/BaseResponse.java
@@ -33,7 +33,7 @@ public class BaseResponse<T> {
     private boolean success;
     @Schema(description = "성공 데이터", nullable = true)
     private T data;
-    @Schema(description = "에러 정보", nullable = true)
+    @Schema(description = "에러 정보", example = "null")
     private ErrorInfo error;
 
     // private 생성자

--- a/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
+++ b/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
@@ -1,5 +1,6 @@
 package com.bookbook.booklink.common.exception;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
@@ -15,31 +16,48 @@ public enum ErrorCode {
     /*
     GlobalExceptionHandler에서 사용
      */
+    @Schema(description = "처리되지 않은 서버 오류입니다.")
     UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "UNKNOWN_ERROR_500", "처리되지 않은 서버 오류입니다."),
+
+    @Schema(description = "접근권한이 없습니다.")
     METHOD_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "METHOD_UNAUTHORIZED_401", "접근권한이 없습니다."),
+
+    @Schema(description = "올바른 값이 아닙니다.")
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED_400", "올바른 값이 아닙니다."),
+
+    @Schema(description = "데이터베이스 처리 중 오류가 발생했습니다.")
     DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "DATABASE_ERROR_500", "데이터베이스 처리 중 오류가 발생했습니다."),
+
+    @Schema(description = "데이터 제약 조건을 위반했습니다.")
     DATA_INTEGRITY_VIOLATION(HttpStatus.BAD_REQUEST, "DATA_INTEGRITY_VIOLATION_400", "데이터 제약 조건을 위반했습니다."),
 
     /*
      * 예외처리 예시
      */
+    @Schema(description = "로그인할 수 없습니다.")
     USER_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "USER_LOGIN_FAILED_400", "로그인할 수 없습니다."),
+
+    @Schema(description = "이미 처리중인 요청입니다.")
     DUPLICATE_REQUEST(HttpStatus.BAD_REQUEST, "DUPLICATE_REQUEST_400", "이미 처리중인 요청입니다."),
 
     /*
      * Library
      */
+    @Schema(description = "해당 ID의 도서관이 존재하지 않습니다.")
     LIBRARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "LIBRARY_NOT_FOUND_400", "해당 ID의 도서관이 존재하지 않습니다."),
 
     /*
      * Review
      */
+    @Schema(description = "존재하지 않는 리뷰입니다.")
     REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "REVIEW_NOT_FOUND_400", "존재하지 않는 리뷰입니다.");
     ;
 
     private final HttpStatus httpStatus;
+    @Schema(description = "에러 코드", example = "UNKNOWN_ERROR_500", implementation = ErrorCode.class)
     private final String code;
+
+    @Schema(description = "사용자 친화적 메시지", example = "처리되지 않은 서버 오류입니다.")
     private final String message;
 
     ErrorCode(HttpStatus httpStatus, String code, String message) {

--- a/src/main/java/com/bookbook/booklink/common/exception/ErrorInfo.java
+++ b/src/main/java/com/bookbook/booklink/common/exception/ErrorInfo.java
@@ -1,6 +1,7 @@
 package com.bookbook.booklink.common.exception;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,12 +9,22 @@ import java.time.Instant;
 
 @Getter
 @Builder
+@Schema(description = "에러 상세 정보")
 public class ErrorInfo {
 
+    @Schema(description = "에러 발생 시간", example = "2025-09-20T07:54:27.043Z")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
     private Instant timestamp;
+
+    @Schema(description = "HTTP 상태 코드", example = "400")
     private int status;
+
+    @Schema(description = "에러 코드", example = "LIBRARY_NOT_FOUND_400", implementation = ErrorCode.class)
     private String code;
+
+    @Schema(description = "사용자 친화적 메시지", example = "해당 ID의 도서관이 존재하지 않습니다.")
     private String message;
+
+    @Schema(description = "요청 경로", example = "/api/library")
     private String path;
 }

--- a/src/main/java/com/bookbook/booklink/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bookbook/booklink/common/exception/GlobalExceptionHandler.java
@@ -1,10 +1,12 @@
 package com.bookbook.booklink.common.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ValidationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
@@ -14,6 +16,7 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.stream.Collectors;
@@ -25,6 +28,7 @@ public class GlobalExceptionHandler {
     public GlobalExceptionHandler() {
     }
 
+    @ExceptionHandler(ValidationException.class)
     private ResponseEntity<BaseResponse<Object>> buildValidationErrorResponse(
             BindingResult bindingResult, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.VALIDATION_FAILED;

--- a/src/main/java/com/bookbook/booklink/library_service/controller/LibraryController.java
+++ b/src/main/java/com/bookbook/booklink/library_service/controller/LibraryController.java
@@ -1,16 +1,11 @@
 package com.bookbook.booklink.library_service.controller;
 
 import com.bookbook.booklink.common.exception.BaseResponse;
+import com.bookbook.booklink.library_service.controller.docs.LibraryApiDocs;
 import com.bookbook.booklink.library_service.model.dto.request.LibraryRegDto;
 import com.bookbook.booklink.library_service.model.dto.request.LibraryUpdateDto;
 import com.bookbook.booklink.library_service.model.dto.response.LibraryDetailDto;
 import com.bookbook.booklink.library_service.service.LibraryService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -26,56 +21,10 @@ import java.util.UUID;
 @RestController
 @Validated
 @RequiredArgsConstructor
-@RequestMapping("/api/library")
-@Tag(name = "Library API", description = "도서관 등록/조회/수정 관련 API")
-public class LibraryController {
+public class LibraryController implements LibraryApiDocs {
     private final LibraryService libraryService;
 
-
-    @Operation(
-            summary = "도서관 등록",
-            description = "사용자 계정에 새로운 도서관을 등록합니다. " +
-                    "하나의 계정당 도서관은 하나만 등록 가능합니다.",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "도서관 등록 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "successResponse",
-                                            value = BaseResponse.SUCCESS_RESPONSE
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "입력값 오류로 인한 예외",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "errorResponse",
-                                            value = BaseResponse.ERROR_RESPONSE
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류로 인한 예외",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "errorResponse",
-                                            value = BaseResponse.ERROR_RESPONSE
-                                    )
-                            )
-                    )
-            }
-    )
-    @PostMapping
+    @Override
     public ResponseEntity<BaseResponse<UUID>> registerLibrary(
             @Valid @RequestBody LibraryRegDto libraryRegDto,
             @RequestHeader("Trace-Id") String traceId
@@ -93,49 +42,7 @@ public class LibraryController {
                 .body(BaseResponse.success(savedLibraryId));
     }
 
-    @Operation(
-            summary = "도서관 수정",
-            description = "사용자 계정에 등록된 도서관을 수정합니다. ",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "도서관 수정 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "successResponse",
-                                            value = BaseResponse.SUCCESS_RESPONSE
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "입력값 오류로 인한 예외",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "errorResponse",
-                                            value = BaseResponse.ERROR_RESPONSE
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류로 인한 예외",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "errorResponse",
-                                            value = BaseResponse.ERROR_RESPONSE
-                                    )
-                            )
-                    )
-            }
-    )
-    @PutMapping
+    @Override
     public ResponseEntity<BaseResponse<UUID>> updateLibrary(
             @Valid @RequestBody LibraryUpdateDto libraryUpdateDto,
             @RequestHeader("Trace-Id") String traceId
@@ -152,49 +59,8 @@ public class LibraryController {
                 .body(BaseResponse.success(updatedLibraryId));
     }
 
-    @Operation(
-            summary = "도서관 삭제",
-            description = "사용자 계정에 등록된 도서관을 삭제합니다. ",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "도서관 삭제 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "successResponse",
-                                            value = BaseResponse.SUCCESS_RESPONSE
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "입력값 오류로 인한 예외",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "errorResponse",
-                                            value = BaseResponse.ERROR_RESPONSE
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류로 인한 예외",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "errorResponse",
-                                            value = BaseResponse.ERROR_RESPONSE
-                                    )
-                            )
-                    )
-            }
-    )
-    @DeleteMapping("/{id}")
+
+    @Override
     public ResponseEntity<BaseResponse<Boolean>> deleteLibrary(
             @PathVariable @NotNull(message = "수정할 도서관의 ID는 필수입니다.") UUID id,
             @RequestHeader("Trace-Id") String traceId
@@ -212,49 +78,7 @@ public class LibraryController {
                 .body(BaseResponse.success(Boolean.TRUE));
     }
 
-    @Operation(
-            summary = "특정 도서관 조회 (단일 객체 반환)",
-            description = "특정 도서관의 상세 정보를 조회합니다.",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "도서관 조회 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "successResponse",
-                                            value = BaseResponse.SUCCESS_RESPONSE
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "입력값 오류로 인한 예외",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "errorResponse",
-                                            value = BaseResponse.ERROR_RESPONSE
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류로 인한 예외",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "errorResponse",
-                                            value = BaseResponse.ERROR_RESPONSE
-                                    )
-                            )
-                    )
-            }
-    )
-    @GetMapping("/{id}")
+    @Override
     public ResponseEntity<BaseResponse<LibraryDetailDto>> getLibrary(
             @PathVariable @NotNull(message = "조회할 도서관의 ID는 필수입니다.") UUID id
     ) {
@@ -264,49 +88,7 @@ public class LibraryController {
                 .body(BaseResponse.success(libraryDetailDto));
     }
 
-    @Operation(
-            summary = "내 주변 3km 이내의 도서관 조회 (리스트 반환)",
-            description = "내 주변 3km 이내의 도서관을 조회해 반환합니다.",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "조회 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "successResponse",
-                                            value = BaseResponse.SUCCESS_RESPONSE
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "입력값 오류로 인한 예외",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "errorResponse",
-                                            value = BaseResponse.ERROR_RESPONSE
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류로 인한 예외",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "errorResponse",
-                                            value = BaseResponse.ERROR_RESPONSE
-                                    )
-                            )
-                    )
-            }
-    )
-    @GetMapping
+    @Override
     public ResponseEntity<BaseResponse<List<LibraryDetailDto>>> getLibraries(
             @RequestParam Double lat,
             @RequestParam Double lng

--- a/src/main/java/com/bookbook/booklink/library_service/controller/docs/LibraryApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/library_service/controller/docs/LibraryApiDocs.java
@@ -1,0 +1,82 @@
+package com.bookbook.booklink.library_service.controller.docs;
+
+import com.bookbook.booklink.common.exception.ApiErrorResponses;
+import com.bookbook.booklink.common.exception.BaseResponse;
+import com.bookbook.booklink.common.exception.ErrorCode;
+import com.bookbook.booklink.library_service.model.dto.request.LibraryRegDto;
+import com.bookbook.booklink.library_service.model.dto.request.LibraryUpdateDto;
+import com.bookbook.booklink.library_service.model.dto.response.LibraryDetailDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "Library API", description = "도서관 등록/조회/수정 관련 API")
+@RequestMapping("/api/library")
+public interface LibraryApiDocs {
+
+    @Operation(
+            summary = "도서관 등록",
+            description = "사용자 계정에 새로운 도서관을 등록합니다. " +
+                    "하나의 계정당 도서관은 하나만 등록 가능합니다."
+    )
+    @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
+    @PostMapping
+    ResponseEntity<BaseResponse<UUID>> registerLibrary(
+            @Valid @RequestBody LibraryRegDto libraryRegDto,
+            @RequestHeader("Trace-Id") String traceId
+    );
+
+    @Operation(
+            summary = "도서관 수정",
+            description = "사용자 계정에 등록된 도서관을 수정합니다."
+    )
+    @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
+    @PutMapping
+    ResponseEntity<BaseResponse<UUID>> updateLibrary(
+            @Valid @RequestBody LibraryUpdateDto libraryUpdateDto,
+            @RequestHeader("Trace-Id") String traceId
+    );
+
+    @Operation(
+            summary = "도서관 삭제",
+            description = "사용자 계정에 등록된 도서관을 삭제합니다."
+    )
+    @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
+    @DeleteMapping("/{id}")
+    ResponseEntity<BaseResponse<Boolean>> deleteLibrary(
+            @PathVariable @NotNull UUID id,
+            @RequestHeader("Trace-Id") String traceId
+    );
+
+    @Operation(
+            summary = "특정 도서관 조회",
+            description = "특정 도서관의 상세 정보를 조회합니다."
+    )
+    @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION, ErrorCode.LIBRARY_NOT_FOUND})
+    @GetMapping("/{id}")
+    ResponseEntity<BaseResponse<LibraryDetailDto>> getLibrary(
+            @PathVariable @NotNull UUID id
+    );
+
+    @Operation(
+            summary = "내 주변 3km 이내 도서관 조회",
+            description = "위치 기반으로 도서관 리스트 반환"
+    )
+    @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
+    @GetMapping
+    ResponseEntity<BaseResponse<List<LibraryDetailDto>>> getLibraries(
+            @RequestParam Double lat,
+            @RequestParam Double lng
+    );
+}

--- a/src/main/java/com/bookbook/booklink/review_service/controller/ReviewController.java
+++ b/src/main/java/com/bookbook/booklink/review_service/controller/ReviewController.java
@@ -1,72 +1,26 @@
 package com.bookbook.booklink.review_service.controller;
 
 import com.bookbook.booklink.common.exception.BaseResponse;
+import com.bookbook.booklink.review_service.controller.docs.ReviewApiDocs;
 import com.bookbook.booklink.review_service.model.dto.request.ReviewCreateDto;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import com.bookbook.booklink.review_service.service.ReviewService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import lombok.RequiredArgsConstructor;
-import com.bookbook.booklink.review_service.service.ReviewService;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/review")
-public class ReviewController {
+public class ReviewController implements ReviewApiDocs {
     private final ReviewService reviewService;
 
-    @Operation(
-            summary = "리뷰 생성",
-            description = "사용자/도서관에 대한 리뷰를 생성합니다. " +
-                    "하나의 거래(도서 대여)당 하나의 리뷰가 가능합니다.",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "리뷰 생성 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "successResponse",
-                                            value = BaseResponse.SUCCESS_RESPONSE
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "입력값 오류로 인한 예외",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "errorResponse",
-                                            value = BaseResponse.ERROR_RESPONSE
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류로 인한 예외",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = BaseResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "errorResponse",
-                                            value = BaseResponse.ERROR_RESPONSE
-                                    )
-                            )
-                    )
-            }
-    )
-    @PostMapping
+    @Override
     public ResponseEntity<BaseResponse<Boolean>> createReview(
             @Valid @RequestBody ReviewCreateDto reviewCreateDto,
             @RequestHeader("Trace-Id") String traceId

--- a/src/main/java/com/bookbook/booklink/review_service/controller/ReviewController.java
+++ b/src/main/java/com/bookbook/booklink/review_service/controller/ReviewController.java
@@ -3,11 +3,13 @@ package com.bookbook.booklink.review_service.controller;
 import com.bookbook.booklink.common.exception.BaseResponse;
 import com.bookbook.booklink.review_service.controller.docs.ReviewApiDocs;
 import com.bookbook.booklink.review_service.model.dto.request.ReviewCreateDto;
+import com.bookbook.booklink.review_service.model.dto.request.ReviewUpdateDto;
 import com.bookbook.booklink.review_service.service.ReviewService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,6 +37,26 @@ public class ReviewController implements ReviewApiDocs {
 
         log.info("[ReviewController] [traceId = {}, userId = {}] create review response success. targetId={}",
                 traceId, userId, reviewCreateDto.getTarget_id());
+
+        return ResponseEntity.ok()
+                .body(BaseResponse.success(Boolean.TRUE));
+    }
+
+    @Override
+    public ResponseEntity<BaseResponse<Boolean>> updateReview(
+            @PathVariable UUID reviewId,
+            @Valid @RequestBody ReviewUpdateDto reviewUpdateDto,
+            @RequestHeader("Trace-Id") String traceId
+    ) {
+        UUID userId = UUID.randomUUID();
+
+        log.info("[ReviewController] [traceId = {}, userId = {}] update review request received. reviewId={}",
+                traceId, userId, reviewId);
+
+        reviewService.updateReview(reviewUpdateDto, reviewId, traceId, userId);
+
+        log.info("[ReviewController] [traceId = {}, userId = {}] update review request success. reviewId={}",
+                traceId, userId, reviewId);
 
         return ResponseEntity.ok()
                 .body(BaseResponse.success(Boolean.TRUE));

--- a/src/main/java/com/bookbook/booklink/review_service/controller/docs/ReviewApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/review_service/controller/docs/ReviewApiDocs.java
@@ -1,0 +1,35 @@
+package com.bookbook.booklink.review_service.controller.docs;
+
+
+import com.bookbook.booklink.common.exception.ApiErrorResponses;
+import com.bookbook.booklink.common.exception.BaseResponse;
+import com.bookbook.booklink.common.exception.ErrorCode;
+import com.bookbook.booklink.review_service.model.dto.request.ReviewCreateDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/api/review")
+@Tag(name = "Review API", description = "리뷰 등록/조회/수정 관련 API")
+public interface ReviewApiDocs {
+
+
+    @Operation(
+            summary = "리뷰 생성",
+            description = "사용자/도서관에 대한 리뷰를 생성합니다. " +
+                    "하나의 거래(도서 대여)당 하나의 리뷰가 가능합니다."
+    )
+    @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<Boolean>> createReview(
+            @Valid @RequestBody ReviewCreateDto reviewCreateDto,
+            @RequestHeader("Trace-Id") String traceId
+    );
+}

--- a/src/main/java/com/bookbook/booklink/review_service/controller/docs/ReviewApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/review_service/controller/docs/ReviewApiDocs.java
@@ -5,14 +5,14 @@ import com.bookbook.booklink.common.exception.ApiErrorResponses;
 import com.bookbook.booklink.common.exception.BaseResponse;
 import com.bookbook.booklink.common.exception.ErrorCode;
 import com.bookbook.booklink.review_service.model.dto.request.ReviewCreateDto;
+import com.bookbook.booklink.review_service.model.dto.request.ReviewUpdateDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RequestMapping("/api/review")
 @Tag(name = "Review API", description = "리뷰 등록/조회/수정 관련 API")
@@ -30,6 +30,17 @@ public interface ReviewApiDocs {
     @PostMapping
     public ResponseEntity<BaseResponse<Boolean>> createReview(
             @Valid @RequestBody ReviewCreateDto reviewCreateDto,
+            @RequestHeader("Trace-Id") String traceId
+    );
+
+    @Operation(
+            summary = "리뷰 수정",
+            description = "사용자/도서관에 대한 리뷰를 수정합니다. 평점, 코멘트 수정가능"
+    )
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<BaseResponse<Boolean>> updateReview(
+            @PathVariable UUID reviewId,
+            @Valid @RequestBody ReviewUpdateDto reviewUpdateDto,
             @RequestHeader("Trace-Id") String traceId
     );
 }

--- a/src/main/java/com/bookbook/booklink/review_service/model/Review.java
+++ b/src/main/java/com/bookbook/booklink/review_service/model/Review.java
@@ -1,6 +1,7 @@
 package com.bookbook.booklink.review_service.model;
 
 import com.bookbook.booklink.review_service.model.dto.request.ReviewCreateDto;
+import com.bookbook.booklink.review_service.model.dto.request.ReviewUpdateDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
@@ -105,6 +106,14 @@ public class Review {
                 .reviewer_id(createDto.getReviewer_id())
                 .target_id(createDto.getTarget_id())
                 .build();
+    }
+
+    /**
+     * 리뷰 업데이트
+     */
+    public void updateReview(ReviewUpdateDto updateDto) {
+        this.rating = updateDto.getRating();
+        this.comment = updateDto.getComment();
     }
 
 }

--- a/src/main/java/com/bookbook/booklink/review_service/model/dto/request/ReviewUpdateDto.java
+++ b/src/main/java/com/bookbook/booklink/review_service/model/dto/request/ReviewUpdateDto.java
@@ -1,0 +1,30 @@
+package com.bookbook.booklink.review_service.model.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ReviewUpdateDto {
+
+    @Schema(
+            description = "별점 범위: 0~5 단위: 1",
+            example = "1",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @Min(0)
+    @Max(5)
+    @NotNull
+    private Short rating;
+
+    @Schema(
+            description = "리뷰 한줄평",
+            example = "정말 친절한 분이에요~!",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Size(max = 100)
+    private String comment;
+}


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

가독성과 책임 분리를 위해 Controller의 Swagger 어노테이션을 인터페이스로 분리함.
예외에 대한 BaseResponse 예시를 구체적으로 보여주기 위한 사용자정의 어노테이션 생성.

### 스크린샷

## 🔗 참고 자료
> 관련된 문서, API 스펙, 이슈 링크 등을 추가해주세요.

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

**체크리스트**

- [x] API 테스트를 통과했나요?
- [x] API 문서화 도구(Swagger)를 적용했나요?
- [x] 산출물 업데이트가 필요한 경우 반영했나요?
- [x] 관련 브랜치 전략 및 머지 대상이 적절하나요?
- [x] 주요 로직에 적절한 로그/주석이 포함되었나요?
- [x] 코드 컨벤션을 준수했나요? (파일명, 네이밍, 포맷 등)
