### PR TITLE
feat: find book & register book

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.modelmapper:modelmapper:3.1.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/bookbook/booklink/book_service/controller/BookController.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/BookController.java
@@ -1,15 +1,18 @@
 package com.bookbook.booklink.book_service.controller;
 
 import com.bookbook.booklink.book_service.controller.docs.BookApiDocs;
+import com.bookbook.booklink.book_service.model.dto.request.BookRegisterDto;
 import com.bookbook.booklink.book_service.model.dto.response.BookResponseDto;
 import com.bookbook.booklink.book_service.service.BookService;
 import com.bookbook.booklink.common.exception.BaseResponse;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -41,5 +44,28 @@ public class BookController implements BookApiDocs {
         return ResponseEntity.ok()
                 .body(BaseResponse.success(book));
     }
+
+    @Override
+    public ResponseEntity<BaseResponse<UUID>> registerBook(
+            @Valid @RequestBody BookRegisterDto bookRegisterDto,
+            @RequestHeader("Trace-Id") String traceId
+    ) {
+        UUID userId = UUID.randomUUID(); // todo : 실제 인증 정보에서 추출
+
+        log.info("[BookController] [traceId = {}, userId = {}] register book request received, isbn={}",
+                traceId, userId, bookRegisterDto.getISBN());
+
+
+        UUID savedBookId = bookService.saveBook(bookRegisterDto, traceId, userId);
+
+        log.info("[BookController] [traceId = {}, userId = {}] register book request success, book={}",
+                traceId, userId, savedBookId);
+
+        return ResponseEntity.ok(BaseResponse.success(savedBookId));
+    }
+
+}
+
+
 }
     

--- a/src/main/java/com/bookbook/booklink/book_service/controller/BookController.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/BookController.java
@@ -3,6 +3,7 @@ package com.bookbook.booklink.book_service.controller;
 import com.bookbook.booklink.book_service.controller.docs.BookApiDocs;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
 import com.bookbook.booklink.book_service.model.dto.response.BookResponseDto;
+import com.bookbook.booklink.book_service.service.BookService;
 import com.bookbook.booklink.book_service.service.LibraryBookService;
 import com.bookbook.booklink.book_service.service.NationalLibraryService;
 import com.bookbook.booklink.common.exception.BaseResponse;
@@ -24,7 +25,7 @@ import java.util.UUID;
 @Validated
 @RequiredArgsConstructor
 public class BookController implements BookApiDocs {
-    private final NationalLibraryService nationalLibraryService;
+    private final BookService bookService;
 
     @Override
     public ResponseEntity<BaseResponse<BookResponseDto>> getBook(
@@ -36,22 +37,15 @@ public class BookController implements BookApiDocs {
         log.info("[BookController] [traceId = {}, userId = {}] register book request received, isbn={}",
                 traceId, userId, isbn);
 
-        try {
-            BookResponseDto result = nationalLibraryService.searchBookByIsbn(isbn);
-            return ResponseEntity.ok()
-                    .body(BaseResponse.success(result));
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.API_FALLBACK_FAIL);
-            // todo : log 찍기
-        }
 
-//        BookResponseDto book = null;
 
-//        log.info("[BookController] [traceId = {}, userId = {}] register book request success, book={}",
-//                traceId, userId, book);
-//
-//        return ResponseEntity.ok()
-//                .body(BaseResponse.success(book));
+        BookResponseDto book = bookService.getBook(isbn, traceId, userId);
+
+        log.info("[BookController] [traceId = {}, userId = {}] register book request success, book={}",
+                traceId, userId, book);
+
+        return ResponseEntity.ok()
+                .body(BaseResponse.success(book));
     }
 }
     

--- a/src/main/java/com/bookbook/booklink/book_service/controller/BookController.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/BookController.java
@@ -1,0 +1,44 @@
+package com.bookbook.booklink.book_service.controller;
+
+import com.bookbook.booklink.book_service.controller.docs.BookApiDocs;
+import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
+import com.bookbook.booklink.book_service.model.dto.response.BookResponseDto;
+import com.bookbook.booklink.book_service.service.LibraryBookService;
+import com.bookbook.booklink.common.exception.BaseResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@Validated
+@RequiredArgsConstructor
+public class BookController implements BookApiDocs {
+
+    @Override
+    @GetMapping()
+    public ResponseEntity<BaseResponse<BookResponseDto>> getBook(
+            @PathVariable @NotNull(message = "조회할 도서의 ISBN 코드는 필수입니다.") String isbn,
+            @RequestHeader("Trace-Id") String traceId
+            ) {
+        UUID userId = UUID.randomUUID(); // todo : 실제 인증 정보에서 추출
+
+        log.info("[BookController] [traceId = {}, userId = {}] register book request received, isbn={}",
+                traceId, userId, isbn);
+
+        BookResponseDto book = null;
+
+        log.info("[BookController] [traceId = {}, userId = {}] register book request success, book={}",
+                traceId, userId, book);
+
+        return ResponseEntity.ok()
+                .body(BaseResponse.success(book));
+    }
+}
+    

--- a/src/main/java/com/bookbook/booklink/book_service/controller/BookController.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/BookController.java
@@ -32,13 +32,12 @@ public class BookController implements BookApiDocs {
     ) {
         UUID userId = UUID.randomUUID(); // todo : 실제 인증 정보에서 추출
 
-        log.info("[BookController] [traceId = {}, userId = {}] register book request received, isbn={}",
+        log.info("[BookController] [traceId = {}, userId = {}] find book request received, isbn={}",
                 traceId, userId, isbn);
-
 
         BookResponseDto book = bookService.getBook(isbn, traceId, userId);
 
-        log.info("[BookController] [traceId = {}, userId = {}] register book request success, book={}",
+        log.info("[BookController] [traceId = {}, userId = {}] find book request success, book={}",
                 traceId, userId, book);
 
         return ResponseEntity.ok()
@@ -65,7 +64,3 @@ public class BookController implements BookApiDocs {
     }
 
 }
-
-
-}
-    

--- a/src/main/java/com/bookbook/booklink/book_service/controller/BookController.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/BookController.java
@@ -1,22 +1,17 @@
 package com.bookbook.booklink.book_service.controller;
 
 import com.bookbook.booklink.book_service.controller.docs.BookApiDocs;
-import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
 import com.bookbook.booklink.book_service.model.dto.response.BookResponseDto;
 import com.bookbook.booklink.book_service.service.BookService;
-import com.bookbook.booklink.book_service.service.LibraryBookService;
-import com.bookbook.booklink.book_service.service.NationalLibraryService;
 import com.bookbook.booklink.common.exception.BaseResponse;
-import com.bookbook.booklink.common.exception.CustomException;
-import com.bookbook.booklink.common.exception.ErrorCode;
-import com.fasterxml.jackson.databind.JsonNode;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
@@ -31,12 +26,11 @@ public class BookController implements BookApiDocs {
     public ResponseEntity<BaseResponse<BookResponseDto>> getBook(
             @PathVariable @NotNull(message = "조회할 도서의 ISBN 코드는 필수입니다.") String isbn,
             @RequestHeader("Trace-Id") String traceId
-            ) {
+    ) {
         UUID userId = UUID.randomUUID(); // todo : 실제 인증 정보에서 추출
 
         log.info("[BookController] [traceId = {}, userId = {}] register book request received, isbn={}",
                 traceId, userId, isbn);
-
 
 
         BookResponseDto book = bookService.getBook(isbn, traceId, userId);

--- a/src/main/java/com/bookbook/booklink/book_service/controller/BookController.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/BookController.java
@@ -4,7 +4,11 @@ import com.bookbook.booklink.book_service.controller.docs.BookApiDocs;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
 import com.bookbook.booklink.book_service.model.dto.response.BookResponseDto;
 import com.bookbook.booklink.book_service.service.LibraryBookService;
+import com.bookbook.booklink.book_service.service.NationalLibraryService;
 import com.bookbook.booklink.common.exception.BaseResponse;
+import com.bookbook.booklink.common.exception.CustomException;
+import com.bookbook.booklink.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -20,9 +24,9 @@ import java.util.UUID;
 @Validated
 @RequiredArgsConstructor
 public class BookController implements BookApiDocs {
+    private final NationalLibraryService nationalLibraryService;
 
     @Override
-    @GetMapping()
     public ResponseEntity<BaseResponse<BookResponseDto>> getBook(
             @PathVariable @NotNull(message = "조회할 도서의 ISBN 코드는 필수입니다.") String isbn,
             @RequestHeader("Trace-Id") String traceId
@@ -32,13 +36,22 @@ public class BookController implements BookApiDocs {
         log.info("[BookController] [traceId = {}, userId = {}] register book request received, isbn={}",
                 traceId, userId, isbn);
 
-        BookResponseDto book = null;
+        try {
+            BookResponseDto result = nationalLibraryService.searchBookByIsbn(isbn);
+            return ResponseEntity.ok()
+                    .body(BaseResponse.success(result));
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.API_FALLBACK_FAIL);
+            // todo : log 찍기
+        }
 
-        log.info("[BookController] [traceId = {}, userId = {}] register book request success, book={}",
-                traceId, userId, book);
+//        BookResponseDto book = null;
 
-        return ResponseEntity.ok()
-                .body(BaseResponse.success(book));
+//        log.info("[BookController] [traceId = {}, userId = {}] register book request success, book={}",
+//                traceId, userId, book);
+//
+//        return ResponseEntity.ok()
+//                .body(BaseResponse.success(book));
     }
 }
     

--- a/src/main/java/com/bookbook/booklink/book_service/controller/LibraryBookController.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/LibraryBookController.java
@@ -1,18 +1,15 @@
 package com.bookbook.booklink.book_service.controller;
 
-import com.bookbook.booklink.book_service.controller.docs.BookApiDocs;
-import com.bookbook.booklink.book_service.model.dto.request.BookRegisterDto;
+import com.bookbook.booklink.book_service.controller.docs.LibraryBookApiDocs;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
+import com.bookbook.booklink.book_service.service.LibraryBookService;
 import com.bookbook.booklink.common.exception.BaseResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
-import com.bookbook.booklink.book_service.service.BookService;
 
 import java.util.UUID;
 
@@ -20,8 +17,8 @@ import java.util.UUID;
 @RestController
 @Validated
 @RequiredArgsConstructor
-public class BookController implements BookApiDocs {
-    private final BookService bookService;
+public class LibraryBookController implements LibraryBookApiDocs {
+    private final LibraryBookService bookService;
 
     @Override
     public ResponseEntity<BaseResponse<UUID>> registerBook(

--- a/src/main/java/com/bookbook/booklink/book_service/controller/LibraryBookController.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/LibraryBookController.java
@@ -5,11 +5,13 @@ import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterD
 import com.bookbook.booklink.book_service.service.LibraryBookService;
 import com.bookbook.booklink.common.exception.BaseResponse;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
@@ -24,7 +26,7 @@ public class LibraryBookController implements LibraryBookApiDocs {
     public ResponseEntity<BaseResponse<UUID>> registerBook(
             @Valid @RequestBody LibraryBookRegisterDto bookRegisterDto,
             @RequestHeader("Trace-Id") String traceId
-            ) {
+    ) {
         UUID userId = UUID.randomUUID(); // todo : 실제 인증 정보에서 추출
 
         log.info("[BookController] [traceId = {}, userId = {}] register book request received, bookId={}",

--- a/src/main/java/com/bookbook/booklink/book_service/controller/docs/BookApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/docs/BookApiDocs.java
@@ -1,31 +1,32 @@
 package com.bookbook.booklink.book_service.controller.docs;
 
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
+import com.bookbook.booklink.book_service.model.dto.response.BookResponseDto;
 import com.bookbook.booklink.common.exception.ApiErrorResponses;
 import com.bookbook.booklink.common.exception.BaseResponse;
 import com.bookbook.booklink.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-@Tag(name = "Library Book API", description = "도서관에 등록된 도서 등록/조회/수정 관련 API")
-@RequestMapping("/api/library-book")
-public interface LibraryBookApiDocs {
+@Tag(name = "Book API", description = "도서 등록/조회/수정 관련 API")
+@RequestMapping("/api/book")
+public interface BookApiDocs {
 
     @Operation(
             summary = "도서 등록",
             description = "도서관에 새로운 도서를 등록합니다. " +
                     "하나의 도서관당 동일 도서는 한 번만 등록 가능합니다."
     )
-    @ApiErrorResponses({ErrorCode.INVALID_CATEGORY_CODE, ErrorCode.DATABASE_ERROR,
+    @ApiErrorResponses({ErrorCode.DATABASE_ERROR, // todo : 발생하는 에러들 추가하기
             ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
-    @PostMapping
-    public ResponseEntity<BaseResponse<UUID>> registerBook(
-            @Valid @RequestBody LibraryBookRegisterDto bookRegisterDto,
+    public ResponseEntity<BaseResponse<BookResponseDto>> getBook(
+            @PathVariable @NotNull(message = "조회할 도서의 ISBN 코드는 필수입니다.") String isbn,
             @RequestHeader("Trace-Id") String traceId
     );
 }

--- a/src/main/java/com/bookbook/booklink/book_service/controller/docs/BookApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/docs/BookApiDocs.java
@@ -25,6 +25,7 @@ public interface BookApiDocs {
     )
     @ApiErrorResponses({ErrorCode.DATABASE_ERROR, // todo : 발생하는 에러들 추가하기
             ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
+    @GetMapping("/{isbn}")
     public ResponseEntity<BaseResponse<BookResponseDto>> getBook(
             @PathVariable @NotNull(message = "조회할 도서의 ISBN 코드는 필수입니다.") String isbn,
             @RequestHeader("Trace-Id") String traceId

--- a/src/main/java/com/bookbook/booklink/book_service/controller/docs/BookApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/docs/BookApiDocs.java
@@ -24,7 +24,7 @@ public interface BookApiDocs {
             description = "도서를 검색합니다. " +
                     "기존 DB에 없을 시 국립중앙도서관 api를 이용해 카테고리 제외한 정보를 반환합니다."
     )
-    @ApiErrorResponses({ErrorCode.DATABASE_ERROR, // todo : 발생하는 에러들 추가하기
+    @ApiErrorResponses({ErrorCode.DATABASE_ERROR, ErrorCode.API_FALLBACK_FAIL, ErrorCode.INVALID_ISBN_CODE,
             ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
     @GetMapping("/{isbn}")
     public ResponseEntity<BaseResponse<BookResponseDto>> getBook(
@@ -36,7 +36,7 @@ public interface BookApiDocs {
             summary = "도서 등록",
             description = "기존 DB에 없던 도서를 등록합니다."
     )
-    @ApiErrorResponses({ErrorCode.DATABASE_ERROR, // todo : 발생하는 에러들 추가하기
+    @ApiErrorResponses({ErrorCode.DATABASE_ERROR, ErrorCode.DUPLICATE_BOOK,
             ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
     @PostMapping
     public ResponseEntity<BaseResponse<UUID>> registerBook(

--- a/src/main/java/com/bookbook/booklink/book_service/controller/docs/BookApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/docs/BookApiDocs.java
@@ -1,5 +1,6 @@
 package com.bookbook.booklink.book_service.controller.docs;
 
+import com.bookbook.booklink.book_service.model.dto.request.BookRegisterDto;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
 import com.bookbook.booklink.book_service.model.dto.response.BookResponseDto;
 import com.bookbook.booklink.common.exception.ApiErrorResponses;
@@ -19,15 +20,27 @@ import java.util.UUID;
 public interface BookApiDocs {
 
     @Operation(
-            summary = "도서 등록",
-            description = "도서관에 새로운 도서를 등록합니다. " +
-                    "하나의 도서관당 동일 도서는 한 번만 등록 가능합니다."
+            summary = "도서 검색",
+            description = "도서를 검색합니다. " +
+                    "기존 DB에 없을 시 국립중앙도서관 api를 이용해 카테고리 제외한 정보를 반환합니다."
     )
     @ApiErrorResponses({ErrorCode.DATABASE_ERROR, // todo : 발생하는 에러들 추가하기
             ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
     @GetMapping("/{isbn}")
     public ResponseEntity<BaseResponse<BookResponseDto>> getBook(
             @PathVariable @NotNull(message = "조회할 도서의 ISBN 코드는 필수입니다.") String isbn,
+            @RequestHeader("Trace-Id") String traceId
+    );
+
+    @Operation(
+            summary = "도서 등록",
+            description = "기존 DB에 없던 도서를 등록합니다."
+    )
+    @ApiErrorResponses({ErrorCode.DATABASE_ERROR, // todo : 발생하는 에러들 추가하기
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
+    @PostMapping
+    public ResponseEntity<BaseResponse<UUID>> registerBook(
+            @Valid @RequestBody BookRegisterDto bookRegisterDto,
             @RequestHeader("Trace-Id") String traceId
     );
 }

--- a/src/main/java/com/bookbook/booklink/book_service/controller/docs/LibraryBookApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/docs/LibraryBookApiDocs.java
@@ -1,26 +1,20 @@
 package com.bookbook.booklink.book_service.controller.docs;
 
-import com.bookbook.booklink.book_service.model.dto.request.BookRegisterDto;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
 import com.bookbook.booklink.common.exception.ApiErrorResponses;
 import com.bookbook.booklink.common.exception.BaseResponse;
 import com.bookbook.booklink.common.exception.ErrorCode;
-import com.bookbook.booklink.library_service.model.dto.request.LibraryRegDto;
-import com.bookbook.booklink.library_service.model.dto.request.LibraryUpdateDto;
-import com.bookbook.booklink.library_service.model.dto.response.LibraryDetailDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
-@Tag(name = "Book API", description = "도서 등록/조회/수정 관련 API")
+@Tag(name = "Library Book API", description = "도서관에 등록된 도서 등록/조회/수정 관련 API")
 @RequestMapping("/api/book")
-public interface BookApiDocs {
+public interface LibraryBookApiDocs {
 
     @Operation(
             summary = "도서 등록",

--- a/src/main/java/com/bookbook/booklink/book_service/model/Book.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/Book.java
@@ -3,22 +3,19 @@ package com.bookbook.booklink.book_service.model;
 import com.bookbook.booklink.book_service.model.dto.request.BookRegisterDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import org.hibernate.annotations.UuidGenerator;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Builder

--- a/src/main/java/com/bookbook/booklink/book_service/model/Book.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/Book.java
@@ -1,7 +1,6 @@
 package com.bookbook.booklink.book_service.model;
 
 import com.bookbook.booklink.book_service.model.dto.request.BookRegisterDto;
-import com.bookbook.booklink.book_service.model.dto.response.NationalLibraryResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
@@ -77,13 +76,15 @@ public class Book {
     @Schema(description = "도서를 보유한 도서관별 정보")
     private List<LibraryBook> libraryBooks = new ArrayList<>();
 
-    public static Book toEntity(NationalLibraryResponseDto dto) {
+    public static Book toEntity(BookRegisterDto dto) {
         return Book.builder()
                 .title(dto.getTitle())
                 .author(dto.getAuthor())
+                .ISBN(dto.getISBN())
                 .publisher(dto.getPublisher())
-                .ISBN(dto.getIsbn())
                 .originalPrice(dto.getOriginalPrice())
+                .publishedDate(dto.getPublishedDate().atStartOfDay())
+                .category(BookCategory.getByCode(dto.getCategory()))
                 .build();
     }
 }

--- a/src/main/java/com/bookbook/booklink/book_service/model/Book.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/Book.java
@@ -1,6 +1,7 @@
 package com.bookbook.booklink.book_service.model;
 
 import com.bookbook.booklink.book_service.model.dto.request.BookRegisterDto;
+import com.bookbook.booklink.book_service.model.dto.response.NationalLibraryResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
@@ -76,14 +77,13 @@ public class Book {
     @Schema(description = "도서를 보유한 도서관별 정보")
     private List<LibraryBook> libraryBooks = new ArrayList<>();
 
-    public static Book toEntity(BookRegisterDto bookRegDto) {
+    public static Book toEntity(NationalLibraryResponseDto dto) {
         return Book.builder()
-                .title(bookRegDto.getName())
-                .author(bookRegDto.getAuthor())
-                .publisher(bookRegDto.getPublisher())
-                .category(BookCategory.getByCode(bookRegDto.getCategory()))
-                .ISBN(bookRegDto.getISBN())
-                .originalPrice(bookRegDto.getOriginalPrice())
+                .title(dto.getTitle())
+                .author(dto.getAuthor())
+                .publisher(dto.getPublisher())
+                .ISBN(dto.getIsbn())
+                .originalPrice(dto.getOriginalPrice())
                 .build();
     }
 }

--- a/src/main/java/com/bookbook/booklink/book_service/model/Book.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/Book.java
@@ -24,7 +24,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
 public class Book {
     @Id
     @UuidGenerator
@@ -37,7 +36,7 @@ public class Book {
     @Column(nullable = false, length = 64)
     @Size(min = 1, max = 64)
     @Schema(description = "도서 이름", example = "마흔에 읽는 쇼펜하우어", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1, maxLength = 64)
-    private String name;
+    private String title;
 
     @Column(nullable = false, length = 16)
     @Size(min = 1, max = 16)
@@ -71,10 +70,9 @@ public class Book {
     @Schema(description = "좋아요 수", example = "14", requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer likeCount = 0;
 
-    @CreatedDate
     @Column(nullable = false, updatable = false)
-    @Schema(description = "도서 등록일", example = "2025-09-22T12:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-    private LocalDateTime createdAt;
+    @Schema(description = "도서 발행일", example = "2025-09-22T12:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    private LocalDateTime publishedDate;
 
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
@@ -83,7 +81,7 @@ public class Book {
 
     public static Book toEntity(BookRegisterDto bookRegDto) {
         return Book.builder()
-                .name(bookRegDto.getName())
+                .title(bookRegDto.getName())
                 .author(bookRegDto.getAuthor())
                 .publisher(bookRegDto.getPublisher())
                 .category(BookCategory.getByCode(bookRegDto.getCategory()))

--- a/src/main/java/com/bookbook/booklink/book_service/model/LibraryBook.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/LibraryBook.java
@@ -1,7 +1,6 @@
 package com.bookbook.booklink.book_service.model;
 
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
-import com.bookbook.booklink.library_service.model.Library;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/request/BookRegisterDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/request/BookRegisterDto.java
@@ -7,13 +7,15 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Getter
 @Schema(description = "도서 등록 요청 DTO")
 public class BookRegisterDto {
     @Schema(description = "도서 이름", example = "마흔에 읽는 쇼펜하우어", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "도서 이름은 필수입니다.")
     @Size(min = 1, max = 64, message = "도서 이름은 1자 이상 64자 이하이어야 합니다.")
-    String name;
+    String title;
 
     @Schema(description = "저자명", example = "강용수", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "저자 이름은 필수입니다.")
@@ -30,10 +32,6 @@ public class BookRegisterDto {
     @Size(min = 3, max = 3, message = "KDC(한국십진분류법) 대분류 코드는 세글자 입니다.")
     String category;
 
-    @Schema(description = "보증금", example = "1000")
-    @Min(value = 0, message = "보증금 가격은 양수여야 합니다.")
-    Integer rentPrice;
-
     @Schema(description = "ISBN 코드", example = "9791192300818", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "ISBN 코드는 필수입니다.")
     @JsonProperty("ISBN")
@@ -43,7 +41,6 @@ public class BookRegisterDto {
     @Min(value = 0, message = "도서 정가는 양수여야 합니다.")
     Integer originalPrice;
 
-    @Schema(description = "대여 가능 여부", example = "true")
-    boolean canBorrow;
-
+    @Schema(description = "발행일", example = "20230903")
+    LocalDate publishedDate;
 }

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/request/BookRegisterDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/request/BookRegisterDto.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/request/LibraryBookRegisterDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/request/LibraryBookRegisterDto.java
@@ -2,7 +2,6 @@ package com.bookbook.booklink.book_service.model.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
@@ -1,9 +1,7 @@
 package com.bookbook.booklink.book_service.model.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 @Getter
 @Setter

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -28,8 +29,8 @@ public class BookResponseDto {
     private String ISBN;
     @Schema(description = "도서 정가", example = "17000", requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer originalPrice;
-    @Schema(description = "도서 발행일", example = "2025-09-22T12:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-    private LocalDateTime publishedDate;
+    @Schema(description = "도서 발행일", example = "2025-09-22", requiredMode = Schema.RequiredMode.REQUIRED)
+    private LocalDate publishedDate;
 
     @Schema(description = "national library 에서 가져오면 true, 우리 데이터베이스에서 가져오면 false", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean foundInNationalLibrary;

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
@@ -1,16 +1,20 @@
 package com.bookbook.booklink.book_service.model.dto.response;
 
+import com.bookbook.booklink.book_service.model.BookCategory;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.UUID;
 
 @Getter
 @Setter
 public class BookResponseDto {
-    private String id;
+    private UUID id;
     private String title;
     private String author;
-    private String isbn;
     private String publisher;
-    private String original_price;
-    private String publishDate;
+    private BookCategory category;
+    private String ISBN;
+    private String originalPrice;
+    private String publishedDate;
 }

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
@@ -1,20 +1,36 @@
 package com.bookbook.booklink.book_service.model.dto.response;
 
 import com.bookbook.booklink.book_service.model.BookCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
 @Setter
+@Builder
+@Schema(description = "도서 등록을 위한 도서 조회 응답 DTO")
 public class BookResponseDto {
+    @Schema(description = "도서 고유 ID (UUID)", example = "550e8400-e29b-41d4-a716-446655440000", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private UUID id;
+    @Schema(description = "도서 이름", example = "마흔에 읽는 쇼펜하우어", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1, maxLength = 64)
     private String title;
+    @Schema(description = "저자명", example = "강용수", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1, maxLength = 16)
     private String author;
+    @Schema(description = "출판사", example = "유노북스", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1, maxLength = 16)
     private String publisher;
+    @Schema(description = "카테고리", example = "GENERALITIES", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private BookCategory category;
+    @Schema(description = "ISBN 코드", example = "9791192300818", requiredMode = Schema.RequiredMode.REQUIRED)
     private String ISBN;
-    private String originalPrice;
-    private String publishedDate;
+    @Schema(description = "도서 정가", example = "17000", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Integer originalPrice;
+    @Schema(description = "도서 발행일", example = "2025-09-22T12:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    private LocalDateTime publishedDate;
+
+    @Schema(description = "우리 데이터베이스에서 가져오면 true, national library에서 가져오면 false", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+    private boolean hasFoundFromOurDatabase;
 }

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
@@ -1,0 +1,6 @@
+package com.bookbook.booklink.book_service.model.dto.response;
+
+import lombok.ToString;
+
+public class BookResponseDto {
+}

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
@@ -31,6 +31,6 @@ public class BookResponseDto {
     @Schema(description = "도서 발행일", example = "2025-09-22T12:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDateTime publishedDate;
 
-    @Schema(description = "우리 데이터베이스에서 가져오면 true, national library에서 가져오면 false", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
-    private boolean hasFoundFromOurDatabase;
+    @Schema(description = "national library 에서 가져오면 true, 우리 데이터베이스에서 가져오면 false", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+    private boolean foundInNationalLibrary;
 }

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/response/BookResponseDto.java
@@ -1,6 +1,17 @@
 package com.bookbook.booklink.book_service.model.dto.response;
 
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
+@Getter
+@Setter
 public class BookResponseDto {
+    private String id;
+    private String title;
+    private String author;
+    private String isbn;
+    private String publisher;
+    private String original_price;
+    private String publishDate;
 }

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/response/NationalLibraryResponseDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/response/NationalLibraryResponseDto.java
@@ -3,16 +3,24 @@ package com.bookbook.booklink.book_service.model.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 @Getter
 @Setter
-public class BookResponseDto {
-    private String id;
+public class NationalLibraryResponseDto {
+    @JsonProperty("TITLE")
     private String title;
+    @JsonProperty("AUTHOR")
     private String author;
+
+    @JsonProperty("EA_ISBN")
     private String isbn;
+
+    @JsonProperty("PUBLISHER")
     private String publisher;
+
+    @JsonProperty("PRE_PRICE")
     private String original_price;
+
+    @JsonProperty("REAL_PUBLISH_DATE")
     private String publishDate;
 }

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/response/NationalLibraryResponseDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/response/NationalLibraryResponseDto.java
@@ -36,7 +36,7 @@ public class NationalLibraryResponseDto {
                 .publisher(publisher)
                 .ISBN(isbn)
                 .originalPrice(Integer.parseInt(originalPrice))
-                .publishedDate(publishedDate.atStartOfDay())
+                .publishedDate(publishedDate)
                 .build();
     }
 }

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/response/NationalLibraryResponseDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/response/NationalLibraryResponseDto.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 public class NationalLibraryResponseDto {
@@ -20,9 +23,20 @@ public class NationalLibraryResponseDto {
     private String publisher;
 
     @JsonProperty("PRE_PRICE")
-    @JsonFormat(shape = JsonFormat.Shape.STRING)
-    private Integer originalPrice;
+    private String originalPrice;
 
     @JsonProperty("REAL_PUBLISH_DATE")
-    private String publishDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMdd")
+    private LocalDate publishedDate;
+
+    public BookResponseDto toBookResponseDto() {
+        return BookResponseDto.builder()
+                .title(title)
+                .author(author)
+                .publisher(publisher)
+                .ISBN(isbn)
+                .originalPrice(Integer.parseInt(originalPrice))
+                .publishedDate(publishedDate.atStartOfDay())
+                .build();
+    }
 }

--- a/src/main/java/com/bookbook/booklink/book_service/model/dto/response/NationalLibraryResponseDto.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/dto/response/NationalLibraryResponseDto.java
@@ -1,5 +1,6 @@
 package com.bookbook.booklink.book_service.model.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
@@ -19,7 +20,8 @@ public class NationalLibraryResponseDto {
     private String publisher;
 
     @JsonProperty("PRE_PRICE")
-    private String original_price;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Integer originalPrice;
 
     @JsonProperty("REAL_PUBLISH_DATE")
     private String publishDate;

--- a/src/main/java/com/bookbook/booklink/book_service/repository/BookRepository.java
+++ b/src/main/java/com/bookbook/booklink/book_service/repository/BookRepository.java
@@ -1,10 +1,10 @@
 package com.bookbook.booklink.book_service.repository;
 
-import jakarta.validation.constraints.NotBlank;
-import org.springframework.stereotype.Repository;
-import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.UUID;
 import com.bookbook.booklink.book_service.model.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
 
 @Repository
 public interface BookRepository extends JpaRepository<Book, UUID> {

--- a/src/main/java/com/bookbook/booklink/book_service/repository/BookRepository.java
+++ b/src/main/java/com/bookbook/booklink/book_service/repository/BookRepository.java
@@ -10,5 +10,7 @@ import com.bookbook.booklink.book_service.model.Book;
 public interface BookRepository extends JpaRepository<Book, UUID> {
 
     boolean existsByISBN(String isbn);
+
+    Book findByISBN(String isbn);
 }
     

--- a/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
@@ -52,7 +52,7 @@ public class BookService {
 
     @Transactional
     protected BookResponseDto saveBookFromApi(NationalLibraryResponseDto apiResponse) {
-        Book newBook = modelMapper.map(apiResponse, Book.class);
+        Book newBook = Book.toEntity(apiResponse);
         Book savedBook = bookRepository.save(newBook);
         return modelMapper.map(savedBook, BookResponseDto.class);
     }

--- a/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
@@ -34,7 +34,7 @@ public class BookService {
         Book book = bookRepository.findByISBN(isbn);
         if (book != null) {
             BookResponseDto dto = modelMapper.map(book, BookResponseDto.class);
-            dto.setHasFoundFromOurDatabase(true);
+            dto.setFoundInNationalLibrary(false);
             log.info("[BookService] [traceId={}, userId={}] found bookId={}", traceId, userId, dto.getId());
             return dto;
         }
@@ -52,7 +52,7 @@ public class BookService {
         }
 
         BookResponseDto dto = apiResponse.toBookResponseDto();
-        dto.setHasFoundFromOurDatabase(false);
+        dto.setFoundInNationalLibrary(true);
         log.info("[LibraryBookService] [traceId = {}, userId = {}] get book success from nationalLibraryApi bookId={}, isbn={}", traceId, userId, null, dto.getISBN());
         return dto;
     }

--- a/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
@@ -41,7 +41,7 @@ public class BookService {
 
         NationalLibraryResponseDto apiResponse;
         try {
-            apiResponse = nationalLibraryService.searchBookByIsbn(isbn);
+            apiResponse = nationalLibraryService.searchBookByIsbn(isbn, traceId, userId);
         } catch (Exception e) {
             log.error("[BookService] [traceId={}, userId={}] API 호출 실패 isbn={}", traceId, userId, isbn, e);
             throw new CustomException(ErrorCode.API_FALLBACK_FAIL);

--- a/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
@@ -4,14 +4,12 @@ import com.bookbook.booklink.book_service.model.Book;
 import com.bookbook.booklink.book_service.model.dto.response.BookResponseDto;
 import com.bookbook.booklink.book_service.model.dto.response.NationalLibraryResponseDto;
 import com.bookbook.booklink.book_service.repository.BookRepository;
-import com.bookbook.booklink.common.exception.BaseResponse;
 import com.bookbook.booklink.common.exception.CustomException;
 import com.bookbook.booklink.common.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;

--- a/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
@@ -1,0 +1,52 @@
+package com.bookbook.booklink.book_service.service;
+
+import com.bookbook.booklink.book_service.model.Book;
+import com.bookbook.booklink.book_service.model.dto.response.BookResponseDto;
+import com.bookbook.booklink.book_service.repository.BookRepository;
+import com.bookbook.booklink.common.exception.BaseResponse;
+import com.bookbook.booklink.common.exception.CustomException;
+import com.bookbook.booklink.common.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookService {
+    private final BookRepository bookRepository;
+    private final NationalLibraryService nationalLibraryService;
+    private final ModelMapper modelMapper;
+
+    @Transactional
+    public BookResponseDto getBook(String isbn, String traceId, UUID userId) {
+        log.info("[LibraryBookService] [traceId = {}, userId = {}] get book initiate isbn={}", traceId, userId, isbn);
+
+        // 기존 데이터베이스에 도서 있는지 확인
+        Book book = bookRepository.findByISBN(isbn);
+        BookResponseDto result;
+        if (book != null) {
+
+        }
+
+
+        // 없으면 api 호출
+        try {
+            BookResponseDto result = nationalLibraryService.searchBookByIsbn(isbn);
+            return ResponseEntity.ok()
+                    .body(BaseResponse.success(result));
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.API_FALLBACK_FAIL);
+            // todo : log 찍기
+        }
+
+        // 저장
+
+        log.info("[LibraryBookService] [traceId = {}, userId = {}] get book initiate bookId={}", traceId, userId, bookId);
+
+    }
+}

--- a/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
@@ -2,6 +2,7 @@ package com.bookbook.booklink.book_service.service;
 
 import com.bookbook.booklink.book_service.model.Book;
 import com.bookbook.booklink.book_service.model.dto.response.BookResponseDto;
+import com.bookbook.booklink.book_service.model.dto.response.NationalLibraryResponseDto;
 import com.bookbook.booklink.book_service.repository.BookRepository;
 import com.bookbook.booklink.common.exception.BaseResponse;
 import com.bookbook.booklink.common.exception.CustomException;
@@ -9,6 +10,7 @@ import com.bookbook.booklink.common.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -26,27 +28,34 @@ public class BookService {
     public BookResponseDto getBook(String isbn, String traceId, UUID userId) {
         log.info("[LibraryBookService] [traceId = {}, userId = {}] get book initiate isbn={}", traceId, userId, isbn);
 
-        // 기존 데이터베이스에 도서 있는지 확인
         Book book = bookRepository.findByISBN(isbn);
-        BookResponseDto result;
         if (book != null) {
-
+            BookResponseDto dto = modelMapper.map(book, BookResponseDto.class);
+            log.info("[BookService] [traceId={}, userId={}] found bookId={}", traceId, userId, dto.getId());
+            return dto;
         }
 
-
-        // 없으면 api 호출
+        NationalLibraryResponseDto apiResponse;
         try {
-            BookResponseDto result = nationalLibraryService.searchBookByIsbn(isbn);
-            return ResponseEntity.ok()
-                    .body(BaseResponse.success(result));
+            apiResponse = nationalLibraryService.searchBookByIsbn(isbn);
         } catch (Exception e) {
+            log.error("[BookService] [traceId={}, userId={}] API 호출 실패 isbn={}", traceId, userId, isbn, e);
             throw new CustomException(ErrorCode.API_FALLBACK_FAIL);
-            // todo : log 찍기
         }
 
-        // 저장
+        if (apiResponse == null) {
+            throw new CustomException(ErrorCode.INVALID_ISBN_CODE);
+        }
 
-        log.info("[LibraryBookService] [traceId = {}, userId = {}] get book initiate bookId={}", traceId, userId, bookId);
+        BookResponseDto result = saveBookFromApi(apiResponse);
+        log.info("[LibraryBookService] [traceId = {}, userId = {}] get book success bookId={}", traceId, userId, result.getId());
+        return result;
+    }
 
+    @Transactional
+    protected BookResponseDto saveBookFromApi(NationalLibraryResponseDto apiResponse) {
+        Book newBook = modelMapper.map(apiResponse, Book.class);
+        Book savedBook = bookRepository.save(newBook);
+        return modelMapper.map(savedBook, BookResponseDto.class);
     }
 }

--- a/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/BookService.java
@@ -34,6 +34,7 @@ public class BookService {
         Book book = bookRepository.findByISBN(isbn);
         if (book != null) {
             BookResponseDto dto = modelMapper.map(book, BookResponseDto.class);
+            dto.setHasFoundFromOurDatabase(true);
             log.info("[BookService] [traceId={}, userId={}] found bookId={}", traceId, userId, dto.getId());
             return dto;
         }
@@ -50,8 +51,10 @@ public class BookService {
             throw new CustomException(ErrorCode.INVALID_ISBN_CODE);
         }
 
-        log.info("[LibraryBookService] [traceId = {}, userId = {}] get book success bookId={}", traceId, userId, result.getId());
-        return null;
+        BookResponseDto dto = apiResponse.toBookResponseDto();
+        dto.setHasFoundFromOurDatabase(false);
+        log.info("[LibraryBookService] [traceId = {}, userId = {}] get book success from nationalLibraryApi bookId={}, isbn={}", traceId, userId, null, dto.getISBN());
+        return dto;
     }
 
     @Transactional

--- a/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class BookService {
+public class LibraryBookService {
     private final BookRepository bookRepository;
     private final LibraryBookRepository libraryBookRepository;
     private final IdempotencyService idempotencyService;

--- a/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
@@ -27,14 +27,14 @@ public class LibraryBookService {
 
     @Transactional
     public UUID registerLibraryBook(LibraryBookRegisterDto bookRegisterDto, String traceId, UUID userId) {
-        log.info("[BookService] [traceId = {}, userId = {}] register library book initiate bookId={}", traceId, userId, bookRegisterDto.getId());
+        log.info("[LibraryBookService] [traceId = {}, userId = {}] register library book initiate bookId={}", traceId, userId, bookRegisterDto.getId());
 
         // 멱등성 체크
-        String key = "book:register:" + traceId;
+        String key = "library-book:register:" + traceId;
         idempotencyService.checkIdempotency(key, 1,
                 () -> LockEvent.builder().key(key).build());
 
-        // register book
+        // find book
         Book book = bookRepository.findById(bookRegisterDto.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
 
@@ -51,7 +51,7 @@ public class LibraryBookService {
         LibraryBook savedLibraryBook = libraryBookRepository.save(libraryBook);
         UUID bookId = savedLibraryBook.getId();
 
-        log.info("[BookService] [traceId = {}, userId = {}] register book success bookId={}", traceId, userId, bookId);
+        log.info("[LibraryBookService] [traceId = {}, userId = {}] register book success bookId={}", traceId, userId, bookId);
 
         return bookId;
     }

--- a/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
@@ -4,18 +4,16 @@ import com.bookbook.booklink.book_service.model.Book;
 import com.bookbook.booklink.book_service.model.LibraryBook;
 import com.bookbook.booklink.book_service.model.LibraryBookCopy;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
+import com.bookbook.booklink.book_service.repository.BookRepository;
 import com.bookbook.booklink.book_service.repository.LibraryBookRepository;
 import com.bookbook.booklink.common.event.LockEvent;
 import com.bookbook.booklink.common.exception.CustomException;
 import com.bookbook.booklink.common.exception.ErrorCode;
 import com.bookbook.booklink.common.service.IdempotencyService;
-import com.bookbook.booklink.library_service.model.Library;
 import jakarta.transaction.Transactional;
-import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import lombok.RequiredArgsConstructor;
-import com.bookbook.booklink.book_service.repository.BookRepository;
 
 import java.util.UUID;
 
@@ -45,7 +43,7 @@ public class LibraryBookService {
 
         // todo : 1:N 유저 맵핑 후, 해당 유저가 해당 ISBN 코드로 책을 등록한 적 있는지 확인
 
-        for(int i = 0; i < bookRegisterDto.getCopies(); i++) {
+        for (int i = 0; i < bookRegisterDto.getCopies(); i++) {
             LibraryBookCopy copy = LibraryBookCopy.toEntity(libraryBook);
             libraryBook.addCopy(copy);
         }

--- a/src/main/java/com/bookbook/booklink/book_service/service/NationalLibraryService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/NationalLibraryService.java
@@ -38,7 +38,7 @@ public class NationalLibraryService {
      * @return JsonNode (응답 데이터)
      * @throws Exception 예외
      */
-    public BookResponseDto searchBookByIsbn(String isbn) throws Exception {
+    public NationalLibraryResponseDto searchBookByIsbn(String isbn) throws Exception {
         StringBuilder urlBuilder = new StringBuilder(apiUrl);
         urlBuilder.append("?cert_key=").append(certKey);
         urlBuilder.append("&result_style=json");
@@ -63,7 +63,6 @@ public class NationalLibraryService {
             }
 
             JsonNode root = objectMapper.readTree(response.toString());
-            log.info("[national-library response] {}", response);
 
             if(!root.path("TOTAL_COUNT").asText().equals("1")) {
                 throw new CustomException(ErrorCode.INVALID_ISBN_CODE);
@@ -74,11 +73,7 @@ public class NationalLibraryService {
                 throw new CustomException(ErrorCode.INVALID_ISBN_CODE);
             }
 
-            log.info("[national-library docs.get(0)] {}", docs.get(0));
-
-
-            // todo : NationalLibraryResponse Dto 로 변경
-            BookResponseDto dto = objectMapper.treeToValue(docs.get(0), BookResponseDto.class);
+            NationalLibraryResponseDto dto = objectMapper.treeToValue(docs.get(0), NationalLibraryResponseDto.class);
 
             return dto;
         } finally {

--- a/src/main/java/com/bookbook/booklink/book_service/service/NationalLibraryService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/NationalLibraryService.java
@@ -16,6 +16,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -37,7 +38,9 @@ public class NationalLibraryService {
      * @return JsonNode (응답 데이터)
      * @throws Exception 예외
      */
-    public NationalLibraryResponseDto searchBookByIsbn(String isbn) throws Exception {
+    public NationalLibraryResponseDto searchBookByIsbn(String isbn, String traceId, UUID userId) throws Exception {
+        log.info("[NationalLibraryService] [traceId = {}, userId = {}] get book from national library initiate isbn={}", traceId, userId, isbn);
+
         StringBuilder urlBuilder = new StringBuilder(apiUrl);
         urlBuilder.append("?cert_key=").append(certKey);
         urlBuilder.append("&result_style=json");
@@ -73,6 +76,7 @@ public class NationalLibraryService {
             }
 
             NationalLibraryResponseDto dto = objectMapper.treeToValue(docs.get(0), NationalLibraryResponseDto.class);
+            log.info("[NationalLibraryService] [traceId = {}, userId = {}] get book from national library success isbn={}", traceId, userId, isbn);
 
             return dto;
         } finally {

--- a/src/main/java/com/bookbook/booklink/book_service/service/NationalLibraryService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/NationalLibraryService.java
@@ -1,6 +1,5 @@
 package com.bookbook.booklink.book_service.service;
 
-import com.bookbook.booklink.book_service.model.dto.response.BookResponseDto;
 import com.bookbook.booklink.book_service.model.dto.response.NationalLibraryResponseDto;
 import com.bookbook.booklink.common.exception.CustomException;
 import com.bookbook.booklink.common.exception.ErrorCode;
@@ -64,7 +63,7 @@ public class NationalLibraryService {
 
             JsonNode root = objectMapper.readTree(response.toString());
 
-            if(!root.path("TOTAL_COUNT").asText().equals("1")) {
+            if (!root.path("TOTAL_COUNT").asText().equals("1")) {
                 throw new CustomException(ErrorCode.INVALID_ISBN_CODE);
             }
 

--- a/src/main/java/com/bookbook/booklink/common/config/ModelMapperConfig.java
+++ b/src/main/java/com/bookbook/booklink/common/config/ModelMapperConfig.java
@@ -1,0 +1,24 @@
+package com.bookbook.booklink.common.config;
+
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModelMapperConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+        ModelMapper modelMapper = new ModelMapper();
+
+        modelMapper.getConfiguration()
+                /* 필드명이 완전히 동일해야 변환 */
+                .setMatchingStrategy(MatchingStrategies.STRICT)
+                .setFieldAccessLevel(
+                        org.modelmapper.config.Configuration.AccessLevel.PRIVATE
+                )
+                .setFieldMatchingEnabled(true);
+        return modelMapper;
+    }
+}

--- a/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
+++ b/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
@@ -55,6 +55,12 @@ public enum ErrorCode {
     @Schema(description = "존재하지 않는 도서입니다.")
     BOOK_NOT_FOUND(HttpStatus.BAD_REQUEST, "BOOK_NOT_FOUND_400", "존재하지 않는 도서입니다."),
 
+    @Schema(description = "공공도서관 api 호출에 실패했습니다.")
+    API_FALLBACK_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "API_FALLBACK_FAIL_500", "공공도서관 api 호출에 실패했습니다."),
+
+    @Schema(description = "유효하지 않은 ISBN 코드입니다.")
+    INVALID_ISBN_CODE(HttpStatus.BAD_REQUEST, "INVALID_ISBN_CODE_400", "유효하지 않은 ISBN 코드입니다."),
+
     /*
      * Review
      */

--- a/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
+++ b/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
@@ -61,6 +61,9 @@ public enum ErrorCode {
     @Schema(description = "유효하지 않은 ISBN 코드입니다.")
     INVALID_ISBN_CODE(HttpStatus.BAD_REQUEST, "INVALID_ISBN_CODE_400", "유효하지 않은 ISBN 코드입니다."),
 
+    @Schema(description = "이미 존재하는 도서입니다.")
+    DUPLICATE_BOOK(HttpStatus.BAD_REQUEST, "DUPLICATE_BOOK_400", "이미 존재하는 도서입니다."),
+
     /*
      * Review
      */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+national-library:
+  api-url: "https://www.nl.go.kr/seoji/SearchApi.do"
+  cert-key: ${NATIONAL_LIBRARY_CERT_KEY}


### PR DESCRIPTION
## 📝작업 내용
- find book : 데이터베이스의 book 을 검색하고, 없으면 국립중앙도서관 api 에서 book을 검색하는 로직을 추가했습니다.
- register book : 국립중앙도서관 api 에서 도서를 검색할 경우, 추가로 저희 데이터베이스에 등록할 수 있도록 api를 만들었습니다.(사용자가 추가 입력해야하는 정보가 있어서 부득이하게 api를 두 개로 쪼갰습니다.)

### 스크린샷
**find book**
<img width="878" height="683" alt="image" src="https://github.com/user-attachments/assets/00d09384-3f29-48aa-ae34-8e040016431f" />

**register book**
<img width="564" height="349" alt="image" src="https://github.com/user-attachments/assets/c344190c-95ad-4b55-bab5-e3e396dc4d23" />


**체크리스트**

- [x] API 테스트를 통과했나요?
- [x] API 문서화 도구(Swagger)를 적용했나요?
- [x] 산출물 업데이트가 필요한 경우 반영했나요?
- [x] 관련 브랜치 전략 및 머지 대상이 적절하나요?
- [x] 주요 로직에 적절한 로그/주석이 포함되었나요?
- [x] 코드 컨벤션을 준수했나요? (파일명, 네이밍, 포맷 등)
