### PR TITLE
회원 조회 기능

### DIFF
--- a/src/main/java/com/bookbook/booklink/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/bookbook/booklink/common/config/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.bookbook.booklink.common.jwt.JwtAuthenticationFilter;
 import com.bookbook.booklink.common.jwt.JwtAuthorizationFilter;
 import com.bookbook.booklink.common.jwt.RefreshTokenService;
 import com.bookbook.booklink.common.jwt.util.JWTUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -60,6 +61,22 @@ public class SecurityConfig {
                 .addFilter(jwtAuthenticationFilter)
                 .addFilterBefore(new JwtAuthorizationFilter(jwtUtil, userDetailsService),
                         UsernamePasswordAuthenticationFilter.class)
+
+                // AccessToken 설정이 없을 시 오류 메세지
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            // 인증 실패 (토큰 없음/만료 등)
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.getWriter().write("{\"message\":\"인증 실패\"}");
+                        })
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            // 인가 실패 (권한 부족)
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                            response.getWriter().write("{\"message\":\"권한 없음\"}");
+                        })
+                )
                 .build();
     }
 

--- a/src/main/java/com/bookbook/booklink/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/bookbook/booklink/common/config/security/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/member/signup", "/api/login", "/api/token/reissue").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilter(jwtAuthenticationFilter)

--- a/src/main/java/com/bookbook/booklink/member/controller/MemberController.java
+++ b/src/main/java/com/bookbook/booklink/member/controller/MemberController.java
@@ -5,12 +5,14 @@ import com.bookbook.booklink.common.jwt.CustomUserDetail.CustomUserDetails;
 import com.bookbook.booklink.member.controller.docs.MemberApiDocs;
 import com.bookbook.booklink.member.model.Member;
 import com.bookbook.booklink.member.model.dto.request.SignUpReqDto;
+import com.bookbook.booklink.member.model.dto.request.UpdateReqDto;
 import com.bookbook.booklink.member.model.dto.response.ProfileResDto;
 import com.bookbook.booklink.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,6 +44,16 @@ public class MemberController implements MemberApiDocs {
 
         return ResponseEntity.ok()
                 .body(BaseResponse.success(response));
+    }
+
+    @Override
+    public ResponseEntity<BaseResponse<ProfileResDto>> updateMyInfo(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @Valid @RequestBody UpdateReqDto reqDto
+    ){
+        UUID memberId = user.getMember().getId();
+        Member updated = memberService.updateProfile(memberId, reqDto);
+        return ResponseEntity.ok(BaseResponse.success(ProfileResDto.from(updated)));
     }
 }
     

--- a/src/main/java/com/bookbook/booklink/member/controller/MemberController.java
+++ b/src/main/java/com/bookbook/booklink/member/controller/MemberController.java
@@ -1,16 +1,21 @@
 package com.bookbook.booklink.member.controller;
 
 import com.bookbook.booklink.common.exception.BaseResponse;
+import com.bookbook.booklink.common.jwt.CustomUserDetail.CustomUserDetails;
 import com.bookbook.booklink.member.controller.docs.MemberApiDocs;
 import com.bookbook.booklink.member.model.Member;
 import com.bookbook.booklink.member.model.dto.request.SignUpReqDto;
+import com.bookbook.booklink.member.model.dto.response.ProfileResDto;
 import com.bookbook.booklink.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +31,17 @@ public class MemberController implements MemberApiDocs {
         Member saved = memberService.signUp(request, traceId);
         return ResponseEntity.ok()
                 .body(BaseResponse.success(Boolean.TRUE));
+    }
+
+    @Override
+    public ResponseEntity<BaseResponse<ProfileResDto>> getMyInfo(
+            @AuthenticationPrincipal CustomUserDetails user
+    ){
+        UUID memberID = user.getMember().getId();
+        ProfileResDto response = memberService.getMyProfile(memberID);
+
+        return ResponseEntity.ok()
+                .body(BaseResponse.success(response));
     }
 }
     

--- a/src/main/java/com/bookbook/booklink/member/controller/MemberController.java
+++ b/src/main/java/com/bookbook/booklink/member/controller/MemberController.java
@@ -3,7 +3,7 @@ package com.bookbook.booklink.member.controller;
 import com.bookbook.booklink.common.exception.BaseResponse;
 import com.bookbook.booklink.member.controller.docs.MemberApiDocs;
 import com.bookbook.booklink.member.model.Member;
-import com.bookbook.booklink.member.model.dto.request.SignUpRequestDto;
+import com.bookbook.booklink.member.model.dto.request.SignUpReqDto;
 import com.bookbook.booklink.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ public class MemberController implements MemberApiDocs {
 
     @Override
     public ResponseEntity<BaseResponse<Boolean>> signup(
-            @Valid @RequestBody SignUpRequestDto request,
+            @Valid @RequestBody SignUpReqDto request,
             @RequestHeader(value = "Trace-Id",required = false) String traceId
     ) {
         Member saved = memberService.signUp(request, traceId);

--- a/src/main/java/com/bookbook/booklink/member/controller/docs/MemberApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/member/controller/docs/MemberApiDocs.java
@@ -5,6 +5,7 @@ import com.bookbook.booklink.common.exception.BaseResponse;
 import com.bookbook.booklink.common.exception.ErrorCode;
 import com.bookbook.booklink.common.jwt.CustomUserDetail.CustomUserDetails;
 import com.bookbook.booklink.member.model.dto.request.SignUpReqDto;
+import com.bookbook.booklink.member.model.dto.request.UpdateReqDto;
 import com.bookbook.booklink.member.model.dto.response.ProfileResDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -36,10 +37,18 @@ public interface MemberApiDocs {
             security = {@SecurityRequirement(name = "bearer-key")}
     )
     @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
-            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION, ErrorCode.USER_NOT_FOUND})
     @GetMapping("/me")
     public ResponseEntity<BaseResponse<ProfileResDto>> getMyInfo(
             @AuthenticationPrincipal CustomUserDetails user
     );
 
+    @Operation(summary = "회원 정보 수정", description = "현재 로그인한 사용자의 정보를 수정합니다.")
+    @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION, ErrorCode.USER_NOT_FOUND})
+    @PutMapping("/update")
+    public ResponseEntity<BaseResponse<ProfileResDto>> updateMyInfo(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @Valid @RequestBody UpdateReqDto reqDto
+    );
 }

--- a/src/main/java/com/bookbook/booklink/member/controller/docs/MemberApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/member/controller/docs/MemberApiDocs.java
@@ -3,32 +3,43 @@ package com.bookbook.booklink.member.controller.docs;
 import com.bookbook.booklink.common.exception.ApiErrorResponses;
 import com.bookbook.booklink.common.exception.BaseResponse;
 import com.bookbook.booklink.common.exception.ErrorCode;
+import com.bookbook.booklink.common.jwt.CustomUserDetail.CustomUserDetails;
 import com.bookbook.booklink.member.model.dto.request.SignUpReqDto;
+import com.bookbook.booklink.member.model.dto.response.ProfileResDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/member")
-@Tag(name = "Member API", description = "회원가입/회원정보 수정/삭제 관련 API")
+@Tag(name = "Member API", description = "회원가입/회원정보 관련 API")
 public interface MemberApiDocs {
 
-    // TODO
-    // 어노테이션 인터페이스 분리 pr merge 시
-    // 형식에 맞추어 변경 예정
     @Operation(
             summary = "회원 가입",
             description = "사용자로 부터 회원 정보를 입력 받아 가입합니다. "
     )
     @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
-            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION,ErrorCode.PASSWORD_POLICY_INVALID})
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION, ErrorCode.PASSWORD_POLICY_INVALID})
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<Boolean>> signup(
             @Valid @RequestBody SignUpReqDto signUpReqDto,
             @RequestHeader("Trace-Id") String traceId
     );
+
+    @Operation(
+            summary = "내 프로필 조회",
+            description = "현재 인증된 사용자의 회원 정보를 반환합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
+    @GetMapping("/me")
+    public ResponseEntity<BaseResponse<ProfileResDto>> getMyInfo(
+            @AuthenticationPrincipal CustomUserDetails user
+    );
+
 }

--- a/src/main/java/com/bookbook/booklink/member/controller/docs/MemberApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/member/controller/docs/MemberApiDocs.java
@@ -3,7 +3,7 @@ package com.bookbook.booklink.member.controller.docs;
 import com.bookbook.booklink.common.exception.ApiErrorResponses;
 import com.bookbook.booklink.common.exception.BaseResponse;
 import com.bookbook.booklink.common.exception.ErrorCode;
-import com.bookbook.booklink.member.model.dto.request.SignUpRequestDto;
+import com.bookbook.booklink.member.model.dto.request.SignUpReqDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -28,7 +28,7 @@ public interface MemberApiDocs {
             ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION,ErrorCode.PASSWORD_POLICY_INVALID})
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<Boolean>> signup(
-            @Valid @RequestBody SignUpRequestDto signUpRequestDto,
+            @Valid @RequestBody SignUpReqDto signUpReqDto,
             @RequestHeader("Trace-Id") String traceId
     );
 }

--- a/src/main/java/com/bookbook/booklink/member/model/Member.java
+++ b/src/main/java/com/bookbook/booklink/member/model/Member.java
@@ -3,7 +3,7 @@ package com.bookbook.booklink.member.model;
 import com.bookbook.booklink.member.code.Provider;
 import com.bookbook.booklink.member.code.Role;
 import com.bookbook.booklink.member.code.Status;
-import com.bookbook.booklink.member.model.dto.request.SignUpRequestDto;
+import com.bookbook.booklink.member.model.dto.request.SignUpReqDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -109,7 +109,7 @@ public class Member {
     @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg", maxLength = 500)
     private String profileImage;
 
-    public static Member ofLocalSignup(SignUpRequestDto req, String encodedPassword) {
+    public static Member ofLocalSignup(SignUpReqDto req, String encodedPassword) {
         return Member.builder()
                 .email(req.getEmail())
                 .password(encodedPassword)

--- a/src/main/java/com/bookbook/booklink/member/model/Member.java
+++ b/src/main/java/com/bookbook/booklink/member/model/Member.java
@@ -4,6 +4,7 @@ import com.bookbook.booklink.member.code.Provider;
 import com.bookbook.booklink.member.code.Role;
 import com.bookbook.booklink.member.code.Status;
 import com.bookbook.booklink.member.model.dto.request.SignUpReqDto;
+import com.bookbook.booklink.member.model.dto.request.UpdateReqDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -123,6 +124,17 @@ public class Member {
                 .status(Status.ACTIVE)
                 .pointBalance(0)
                 .build();
+    }
+
+    /**
+     * 회원 정보 수정
+     * nickname, address, phone, profileImage 업데이트
+     */
+    public void updateMemberInfo(UpdateReqDto dto) {
+        this.nickname = dto.getNickname();
+        this.address = dto.getAddress();
+        this.phone = dto.getPhone();
+        this.profileImage = dto.getProfileImage();
     }
 }
     

--- a/src/main/java/com/bookbook/booklink/member/model/dto/request/SignUpReqDto.java
+++ b/src/main/java/com/bookbook/booklink/member/model/dto/request/SignUpReqDto.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class SignUpRequestDto {
+public class SignUpReqDto {
     @Email
     @NotBlank
     @Schema(description = "이메일 (로그인 ID)", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED, maxLength = 150)

--- a/src/main/java/com/bookbook/booklink/member/model/dto/request/UpdateReqDto.java
+++ b/src/main/java/com/bookbook/booklink/member/model/dto/request/UpdateReqDto.java
@@ -1,0 +1,30 @@
+package com.bookbook.booklink.member.model.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "회원 정보 수정 요청 DTO")
+public class UpdateReqDto {
+
+    @Size(min = 2, max = 20)
+    @Schema(description = "닉네임", example = "북북이")
+    private String nickname;
+
+    @Size(min = 5, max = 200)
+    @Schema(description = "주소", example = "서울시 강남구 역삼동 123-45")
+    private String address;
+
+    @Pattern(regexp = "^01[0-9]-[0-9]{3,4}-[0-9]{4}$",
+             message = "전화번호 형식은 01x-xxxx-xxxx 입니다.")
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    private String phone;
+
+    @Size(max = 500)
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+    private String profileImage;
+}

--- a/src/main/java/com/bookbook/booklink/member/model/dto/response/ProfileResDto.java
+++ b/src/main/java/com/bookbook/booklink/member/model/dto/response/ProfileResDto.java
@@ -1,4 +1,69 @@
 package com.bookbook.booklink.member.model.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "내 프로필 응답 DTO")
 public class ProfileResDto {
+
+    @Schema(description = "회원 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
+    private UUID id;
+
+    @Schema(description = "이메일(로그인 ID)", example = "test@example.com")
+    private String email;
+
+    @Schema(description = "이름", example = "홍길동")
+    private String name;
+
+    @Schema(description = "닉네임", example = "북북이")
+    private String nickName;
+
+    @Schema(description = "주소", example = "서울시 강남구 역삼동 123-45")
+    private String address;
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    private String phone;
+
+    @Schema(description = "가입 경로", example = "LOCAL")
+    private String provider;
+
+    @Schema(description = "역할", example = "CUSTOMER")
+    private String role;
+
+    @Schema(description = "상태", example = "ACTIVE")
+    private String status;
+
+    @Schema(description = "보유 포인트", example = "1000")
+    private Integer pointBalance;
+
+    @Schema(description = "가입 일자", example = "2025-09-23T20:05:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+    private String profileImage;
+
+    public static ProfileResDto from(com.bookbook.booklink.member.model.Member m) {
+        return ProfileResDto.builder()
+                .id(m.getId())
+                .email(m.getEmail())
+                .name(m.getName())
+                .nickName(m.getNickname())
+                .address(m.getAddress())
+                .phone(m.getPhone())
+                .provider(m.getProvider().name())
+                .role(m.getRole().name())
+                .status(m.getStatus().name())
+                .pointBalance(m.getPointBalance())
+                .createdAt(m.getCreatedAt())
+                .profileImage(m.getProfileImage())
+                .build();
+    }
 }

--- a/src/main/java/com/bookbook/booklink/member/model/dto/response/ProfileResDto.java
+++ b/src/main/java/com/bookbook/booklink/member/model/dto/response/ProfileResDto.java
@@ -1,0 +1,4 @@
+package com.bookbook.booklink.member.model.dto.response;
+
+public class ProfileResDto {
+}

--- a/src/main/java/com/bookbook/booklink/member/model/dto/response/SignUpResDto.java
+++ b/src/main/java/com/bookbook/booklink/member/model/dto/response/SignUpResDto.java
@@ -1,6 +1,5 @@
 package com.bookbook.booklink.member.model.dto.response;
 
-import com.bookbook.booklink.member.model.dto.request.SignUpRequestDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +11,7 @@ import java.util.UUID;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class SignUpResponseDto {
+public class SignUpResDto {
     //TODO
     // jwt토큰 발급 시 회원가입 완료 후 바로 토큰 브라우저에 응답하도록 추가
     private UUID id;
@@ -22,8 +21,8 @@ public class SignUpResponseDto {
     private String nickname;
     private String profileImage;
 
-    public static SignUpResponseDto from(SignUpResponseDto dto) {
-        return SignUpResponseDto.builder()
+    public static SignUpResDto from(SignUpResDto dto) {
+        return SignUpResDto.builder()
                 .id(dto.getId())
                 .email(dto.getEmail())
                 .name(dto.getName())

--- a/src/main/java/com/bookbook/booklink/member/service/MemberService.java
+++ b/src/main/java/com/bookbook/booklink/member/service/MemberService.java
@@ -62,9 +62,36 @@ public class MemberService {
         return saveMember;
     }
 
+    /**
+     * 주어진 UUID로 Member 엔티티를 조회합니다.
+     * <p>
+     * DB에서 해당 ID의 Member가 존재하지 않을 경우 {@link CustomException}을 발생시킵니다.
+     * 이 메서드는 여러 서비스 계층에서 공통적으로 사용할 수 있는
+     * "회원 조회 유틸리티" 메서드 역할을 합니다.
+     *
+     * @param memberID 조회할 회원의 UUID
+     * @return Member 엔티티
+     * @throws CustomException {@link ErrorCode#USER_NOT_FOUND} - 회원이 존재하지 않는 경우
+     */
+    @Transactional(readOnly = true)
+    public Member getMemberOrThrow(UUID memberID){
+        return memberRepository.findById(memberID)
+                .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    /**
+     * 로그인한 사용자의 프로필 정보를 조회합니다.
+     * <p>
+     * 내부적으로 {@link #getMemberOrThrow(UUID)}를 호출하여 Member 엔티티를 가져온 뒤,
+     * {@link ProfileResDto} 형태로 변환하여 반환합니다.
+     *
+     * @param memberId 로그인한 회원의 UUID
+     * @return 프로필 응답 DTO ({@link ProfileResDto})
+     * @throws CustomException {@link ErrorCode#USER_NOT_FOUND} - 회원이 존재하지 않는 경우
+     */
+    @Transactional(readOnly = true)
     public ProfileResDto getMyProfile(UUID memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Member member = getMemberOrThrow(memberId);
         return ProfileResDto.from(member);
     }
 }

--- a/src/main/java/com/bookbook/booklink/member/service/MemberService.java
+++ b/src/main/java/com/bookbook/booklink/member/service/MemberService.java
@@ -6,6 +6,7 @@ import com.bookbook.booklink.common.exception.ErrorCode;
 import com.bookbook.booklink.common.service.IdempotencyService;
 import com.bookbook.booklink.member.model.Member;
 import com.bookbook.booklink.member.model.dto.request.SignUpReqDto;
+import com.bookbook.booklink.member.model.dto.request.UpdateReqDto;
 import com.bookbook.booklink.member.model.dto.response.ProfileResDto;
 import com.bookbook.booklink.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -93,6 +94,30 @@ public class MemberService {
     public ProfileResDto getMyProfile(UUID memberId) {
         Member member = getMemberOrThrow(memberId);
         return ProfileResDto.from(member);
+    }
+
+    /**
+     * 회원 프로필 수정
+     *
+     * <p>회원 ID를 통해 기존 회원 엔티티를 조회한 뒤,
+     * 요청 DTO(UpdateReqDto)에서 전달된 값으로 회원 정보를 업데이트합니다.
+     *
+     * <ul>
+     *   <li>닉네임, 주소, 전화번호, 프로필 이미지 등 기본 프로필 정보 수정 가능</li>
+     *   <li>존재하지 않는 회원 ID일 경우 {@link CustomException} with {@link ErrorCode#USER_NOT_FOUND} 발생</li>
+     *   <li>트랜잭션 내에서 동작하며 수정된 회원 엔티티는 DB에 즉시 반영됩니다.</li>
+     * </ul>
+     *
+     * @param memberId 수정할 회원의 고유 ID(UUID)
+     * @param reqDto   회원 수정 요청 DTO (닉네임, 주소, 전화번호, 프로필 이미지 포함)
+     * @return 수정이 완료된 회원 엔티티
+     * @throws CustomException 회원 ID가 존재하지 않을 경우 예외 발생
+     */
+    @Transactional
+    public Member updateProfile(UUID memberId, UpdateReqDto reqDto) {
+        Member member = getMemberOrThrow(memberId);
+        member.updateMemberInfo(reqDto);
+        return memberRepository.save(member);
     }
 }
     

--- a/src/main/java/com/bookbook/booklink/member/service/MemberService.java
+++ b/src/main/java/com/bookbook/booklink/member/service/MemberService.java
@@ -6,12 +6,15 @@ import com.bookbook.booklink.common.exception.ErrorCode;
 import com.bookbook.booklink.common.service.IdempotencyService;
 import com.bookbook.booklink.member.model.Member;
 import com.bookbook.booklink.member.model.dto.request.SignUpReqDto;
+import com.bookbook.booklink.member.model.dto.response.ProfileResDto;
 import com.bookbook.booklink.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -57,6 +60,12 @@ public class MemberService {
                 traceId, saveMember.getName());
 
         return saveMember;
+    }
+
+    public ProfileResDto getMyProfile(UUID memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return ProfileResDto.from(member);
     }
 }
     


### PR DESCRIPTION
## 📝작업 내용
♻️ refactor: Rename DTO classes for consistency
- Dto 관련 코드컨밴션 맞추어 reqDto,resDto로 변경하였습니다.
🔒 fix: Allow Swagger UI access in SecurityConfig
- swagger 문서 확인하려하니 접근이 안되어 securityConfig에 경로 추가하였습니다.
✨ feat: Implement member info retrieval API
- 회원 조회를 하는 기능을 추가하였습니다.
🔒 feat: Add custom exception handling for authentication/authorization error
- Bearer 토큰을 넣지 않고 API 테스트를 하였을 시 아무 오류를 반환하지 않아
- 인증토큰이 없다는 오류 반환하도록 추가하였습니다.

# <u>☑️ 작업 내용 2 </u>
✨ feat: Implement member profile update API
- 회원 정보를 수정하는 기능을 구현하였습니다.
---
### 스크린샷
- 회원 조회
<img width="837" height="766" alt="스크린샷 2025-09-26 021954" src="https://github.com/user-attachments/assets/55bb26e2-7528-459f-b15b-fef34be505ab" />

---

- 회원 수정
<img width="698" height="801" alt="스크린샷 2025-09-26 193356" src="https://github.com/user-attachments/assets/ad25f271-07f7-4ecb-91e2-743d29e05b85" />


**체크리스트**

- [x] API 테스트를 통과했나요?
- [x] API 문서화 도구(Swagger)를 적용했나요?
- [x] 산출물 업데이트가 필요한 경우 반영했나요?
- [x] 관련 브랜치 전략 및 머지 대상이 적절하나요?
- [x] 주요 로직에 적절한 로그/주석이 포함되었나요?
- [x] 코드 컨벤션을 준수했나요? (파일명, 네이밍, 포맷 등)
