### PR TITLE
feat: delete library book

### DIFF
--- a/src/main/java/com/bookbook/booklink/book_service/controller/LibraryBookController.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/LibraryBookController.java
@@ -6,10 +6,12 @@ import com.bookbook.booklink.book_service.model.dto.request.LibraryBookUpdateDto
 import com.bookbook.booklink.book_service.service.LibraryBookService;
 import com.bookbook.booklink.common.exception.BaseResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
@@ -57,6 +59,23 @@ public class LibraryBookController implements LibraryBookApiDocs {
         log.info("[LibraryBookController] [traceId = {}, userId = {}] update library book request success, libraryBookId={}",
                 traceId, userId, updateBookDto.getId());
 
+        return ResponseEntity.ok(BaseResponse.success(null));
+    }
+
+    @Override
+    public ResponseEntity<BaseResponse<Void>> deleteLibraryBook(
+            @PathVariable @NotNull(message = "삭제할 도서관별 도서의 id는 필수입니다.") UUID libraryBookId,
+            @RequestHeader("Trace-Id") String traceId
+    ) {
+        UUID userId = UUID.randomUUID(); // todo : 실제 인증 정보에서 추출
+
+        log.info("[LibraryBookController] [traceId = {}, userId = {}] delete library book request received, libraryBookId={}",
+                traceId, userId, libraryBookId);
+
+        bookService.deleteLibraryBook(libraryBookId, traceId, userId);
+
+        log.info("[LibraryBookController] [traceId = {}, userId = {}] delete library book request success, libraryBookId={}",
+                traceId, userId, libraryBookId);
         return ResponseEntity.ok(BaseResponse.success(null));
     }
 }

--- a/src/main/java/com/bookbook/booklink/book_service/controller/docs/LibraryBookApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/docs/LibraryBookApiDocs.java
@@ -8,6 +8,7 @@ import com.bookbook.booklink.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -40,6 +41,18 @@ public interface LibraryBookApiDocs {
     @PatchMapping
     public ResponseEntity<BaseResponse<Void>> updateLibraryBook(
             @Valid @RequestBody LibraryBookUpdateDto updateBookDto,
+            @RequestHeader("Trace-Id") String traceId
+    );
+
+    @Operation(
+            summary = "도서관별 도서 삭제",
+            description = "도서관에 등록된 도서를 삭제합니다."
+    )
+    @ApiErrorResponses({ErrorCode.INVALID_CATEGORY_CODE, // todo : 에러 코드 추가
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
+    @DeleteMapping("/{libraryBookId}")
+    public ResponseEntity<BaseResponse<Void>> deleteLibraryBook(
+            @PathVariable @NotNull(message = "삭제할 도서관별 도서의 id는 필수입니다.") UUID libraryBookId,
             @RequestHeader("Trace-Id") String traceId
     );
 }

--- a/src/main/java/com/bookbook/booklink/book_service/controller/docs/LibraryBookApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/book_service/controller/docs/LibraryBookApiDocs.java
@@ -35,8 +35,7 @@ public interface LibraryBookApiDocs {
             summary = "도서관별 도서 수정",
             description = "도서관에 등록된 도서의 보증금, 보유 권수를 수정합니다."
     )
-    @ApiErrorResponses({ErrorCode.INVALID_CATEGORY_CODE, ErrorCode.BOOK_NOT_FOUND,
-            ErrorCode.NOT_ENOUGH_AVAILABLE_COPIES_TO_REMOVE, ErrorCode.LIBRARY_BOOK_COPIES_MISMATCH,
+    @ApiErrorResponses({ErrorCode.BOOK_NOT_FOUND, ErrorCode.NOT_ENOUGH_AVAILABLE_COPIES_TO_REMOVE, ErrorCode.LIBRARY_BOOK_COPIES_MISMATCH,
             ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
     @PatchMapping
     public ResponseEntity<BaseResponse<Void>> updateLibraryBook(
@@ -48,8 +47,7 @@ public interface LibraryBookApiDocs {
             summary = "도서관별 도서 삭제",
             description = "도서관에 등록된 도서를 삭제합니다."
     )
-    @ApiErrorResponses({ErrorCode.INVALID_CATEGORY_CODE, // todo : 에러 코드 추가
-            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
+    @ApiErrorResponses({ErrorCode.CANNOT_DELETE_BORROWED_BOOK})
     @DeleteMapping("/{libraryBookId}")
     public ResponseEntity<BaseResponse<Void>> deleteLibraryBook(
             @PathVariable @NotNull(message = "삭제할 도서관별 도서의 id는 필수입니다.") UUID libraryBookId,

--- a/src/main/java/com/bookbook/booklink/book_service/model/LibraryBook.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/LibraryBook.java
@@ -1,7 +1,6 @@
 package com.bookbook.booklink.book_service.model;
 
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
-import com.bookbook.booklink.book_service.model.dto.request.LibraryBookUpdateDto;
 import com.bookbook.booklink.common.exception.CustomException;
 import com.bookbook.booklink.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -164,5 +163,10 @@ public class LibraryBook {
 
     public void updateDeposit(int deposit) {
         this.deposit = deposit;
+    }
+
+    public boolean hasBorrowedCopies() {
+        return getCopiesList().stream()
+                .anyMatch(copy -> copy.getStatus() != BookStatus.AVAILABLE);
     }
 }

--- a/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
@@ -69,20 +69,14 @@ public class LibraryBookService {
         log.info("[LibraryBookService] [traceId = {}, userId = {}] update library book success libraryBook={}", traceId, userId, libraryBook);
     }
 
+    @Transactional
     public void deleteLibraryBook(UUID libraryBookId, String traceId, UUID userId) {
         log.info("[LibraryBookService] [traceId = {}, userId = {}] delete library book initiate libraryBookId={}", traceId, userId, libraryBookId);
 
         LibraryBook libraryBook = libraryBookRepository.findById(libraryBookId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
 
-        boolean hasBorrowedCopies = libraryBook.hasBorrowedCopies();
-
-        if (hasBorrowedCopies) {
-            throw new CustomException(ErrorCode.CANNOT_DELETE_BORROWED_BOOK);
-        }
-
-        libraryBookRepository.delete(libraryBook);
-
+        libraryBook.softDelete();
         log.info("[LibraryBookService] [traceId = {}, userId = {}] delete library book success libraryBookId={}", traceId, userId, libraryBookId);
     }
 }

--- a/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
@@ -1,9 +1,7 @@
 package com.bookbook.booklink.book_service.service;
 
 import com.bookbook.booklink.book_service.model.Book;
-import com.bookbook.booklink.book_service.model.BookStatus;
 import com.bookbook.booklink.book_service.model.LibraryBook;
-import com.bookbook.booklink.book_service.model.LibraryBookCopy;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookUpdateDto;
 import com.bookbook.booklink.book_service.repository.BookRepository;
@@ -17,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -70,6 +67,23 @@ public class LibraryBookService {
         if (updateBookDto.getDeposit() != null) libraryBook.updateDeposit(updateBookDto.getDeposit());
 
         log.info("[LibraryBookService] [traceId = {}, userId = {}] update library book success libraryBook={}", traceId, userId, libraryBook);
+    }
+
+    public void deleteLibraryBook(UUID libraryBookId, String traceId, UUID userId) {
+        log.info("[LibraryBookService] [traceId = {}, userId = {}] delete library book initiate libraryBookId={}", traceId, userId, libraryBookId);
+
+        LibraryBook libraryBook = libraryBookRepository.findById(libraryBookId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
+
+        boolean hasBorrowedCopies = libraryBook.hasBorrowedCopies();
+
+        if (hasBorrowedCopies) {
+            throw new CustomException(ErrorCode.CANNOT_DELETE_BORROWED_BOOK);
+        }
+
+        libraryBookRepository.delete(libraryBook);
+
+        log.info("[LibraryBookService] [traceId = {}, userId = {}] delete library book success libraryBookId={}", traceId, userId, libraryBookId);
     }
 }
     

--- a/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
+++ b/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
@@ -98,6 +98,9 @@ public enum ErrorCode {
     @Schema(description = "삭제할 도서 개수가 충분하지 않습니다.")
     NOT_ENOUGH_AVAILABLE_COPIES_TO_REMOVE(HttpStatus.BAD_REQUEST, "BOOK_BAD_REQUEST_400", "삭제할 도서 개수가 충분하지 않습니다."),
 
+    @Schema(description = "대여중인 도서가 있을 때는 삭제할 수 없습니다.")
+    CANNOT_DELETE_BORROWED_BOOK(HttpStatus.BAD_REQUEST, "BOOK_BAD_REQUEST_400", "대여중인 도서가 있을 때는 삭제할 수 없습니다."),
+
     /*
      * Review
      */


### PR DESCRIPTION
## 📝작업 내용
- 도서관별 도서를 삭제할 수 있는 기능을 추가했습니다.(소프트 딜리트)

### 스크린샷
<img width="826" height="696" alt="image" src="https://github.com/user-attachments/assets/5ba7fe07-de8a-4c6a-80f8-b42285bb4ae2" />

## 🔗 참고 자료
- `LibraryBook` 엔티티에 `@SQLRestrice("deleted_at IS NULL")`  추가했는데, 이거 하면 검색할 때 따로 조건을 달아주지 않아도 자동으로 삭제된 것은 필터링되고 검색된다고 해서 추가했습니다.

**체크리스트**

- [x] API 테스트를 통과했나요?
- [x] API 문서화 도구(Swagger)를 적용했나요?
- [x] 산출물 업데이트가 필요한 경우 반영했나요?
- [x] 관련 브랜치 전략 및 머지 대상이 적절하나요?
- [x] 주요 로직에 적절한 로그/주석이 포함되었나요?
- [x] 코드 컨벤션을 준수했나요? (파일명, 네이밍, 포맷 등)
