### PR TITLE
도서관 목록 조회에 이름으로 검색기능 추가

### DIFF
--- a/src/main/java/com/bookbook/booklink/auth_service/model/Member.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/model/Member.java
@@ -5,28 +5,19 @@ import com.bookbook.booklink.auth_service.code.Role;
 import com.bookbook.booklink.auth_service.code.Status;
 import com.bookbook.booklink.auth_service.model.dto.request.SignUpReqDto;
 import com.bookbook.booklink.auth_service.model.dto.request.UpdateReqDto;
+import com.bookbook.booklink.library_service.model.Library;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
-
-import jakarta.persistence.Id;
-import jakarta.persistence.Column;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Entity;
-
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Min;
-import lombok.Getter;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UuidGenerator;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
 
 @Entity
 
@@ -109,6 +100,9 @@ public class Member {
     @Column(length = 500)
     @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg", maxLength = 500)
     private String profileImage;
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Library library;
 
     public static Member ofLocalSignup(SignUpReqDto req, String encodedPassword) {
         return Member.builder()

--- a/src/main/java/com/bookbook/booklink/book_service/model/Book.java
+++ b/src/main/java/com/bookbook/booklink/book_service/model/Book.java
@@ -13,8 +13,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -33,22 +31,26 @@ public class Book {
     @Column(nullable = false, length = 64)
     @Size(min = 1, max = 64)
     @Schema(description = "도서 이름", example = "마흔에 읽는 쇼펜하우어", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1, maxLength = 64)
+    @Getter
     private String title;
 
     @Column(nullable = false, length = 16)
     @Size(min = 1, max = 16)
     @Schema(description = "저자명", example = "강용수", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1, maxLength = 16)
+    @Getter
     private String author;
 
     @Column(nullable = false, length = 16)
     @Size(min = 1, max = 16)
     @Schema(description = "출판사", example = "유노북스", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1, maxLength = 16)
+    @Getter
     private String publisher;
 
     @Column(nullable = false)
     @NotNull
     @Enumerated(EnumType.STRING)
     @Schema(description = "카테고리", example = "GENERALITIES", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Getter
     private BookCategory category;
 
     @Column(unique = true, length = 13)

--- a/src/main/java/com/bookbook/booklink/book_service/repository/LibraryBookRepository.java
+++ b/src/main/java/com/bookbook/booklink/book_service/repository/LibraryBookRepository.java
@@ -1,12 +1,25 @@
 package com.bookbook.booklink.book_service.repository;
 
 import com.bookbook.booklink.book_service.model.LibraryBook;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface LibraryBookRepository extends JpaRepository<LibraryBook, UUID> {
+
+    @Query("SELECT lb " +
+            "FROM LibraryBook lb " +
+            "JOIN FETCH lb.book b " +
+            "WHERE lb.library.id = :libraryId " +
+            "ORDER BY b.likeCount DESC")
+    List<LibraryBook> findTop5BooksByLibraryOrderByLikeCount(@Param("libraryId") UUID libraryId, Pageable pageable);
+
+
 }
     

--- a/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
@@ -4,7 +4,6 @@ import com.bookbook.booklink.book_service.model.Book;
 import com.bookbook.booklink.book_service.model.LibraryBook;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookUpdateDto;
-import com.bookbook.booklink.book_service.repository.BookRepository;
 import com.bookbook.booklink.book_service.repository.LibraryBookRepository;
 import com.bookbook.booklink.common.event.LockEvent;
 import com.bookbook.booklink.common.exception.CustomException;
@@ -15,8 +14,10 @@ import com.bookbook.booklink.library_service.service.LibraryService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -80,6 +81,11 @@ public class LibraryBookService {
 
         libraryBook.softDelete();
         log.info("[LibraryBookService] [traceId = {}, userId = {}] delete library book success libraryBookId={}", traceId, userId, libraryBookId);
+    }
+
+
+    public List<LibraryBook> findTop5Books(UUID libraryId) {
+        return libraryBookRepository.findTop5BooksByLibraryOrderByLikeCount(libraryId, PageRequest.of(0, 5));
     }
 }
     

--- a/src/main/java/com/bookbook/booklink/library_service/controller/LibraryController.java
+++ b/src/main/java/com/bookbook/booklink/library_service/controller/LibraryController.java
@@ -100,10 +100,11 @@ public class LibraryController implements LibraryApiDocs {
     @Override
     public ResponseEntity<BaseResponse<List<LibraryDetailDto>>> getLibraries(
             @RequestParam Double lat,
-            @RequestParam Double lng
+            @RequestParam Double lng,
+            @RequestParam(required = false) String name
     ) {
 
-        List<LibraryDetailDto> result = libraryService.getLibraries(lat, lng);
+        List<LibraryDetailDto> result = libraryService.getLibraries(lat, lng, name);
 
         return ResponseEntity.ok()
                 .body(BaseResponse.success(result));

--- a/src/main/java/com/bookbook/booklink/library_service/controller/docs/LibraryApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/library_service/controller/docs/LibraryApiDocs.java
@@ -82,6 +82,7 @@ public interface LibraryApiDocs {
     @GetMapping
     ResponseEntity<BaseResponse<List<LibraryDetailDto>>> getLibraries(
             @RequestParam Double lat,
-            @RequestParam Double lng
+            @RequestParam Double lng,
+            @RequestParam(required = false) String name
     );
 }

--- a/src/main/java/com/bookbook/booklink/library_service/controller/docs/LibraryApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/library_service/controller/docs/LibraryApiDocs.java
@@ -1,5 +1,6 @@
 package com.bookbook.booklink.library_service.controller.docs;
 
+import com.bookbook.booklink.auth_service.model.Member;
 import com.bookbook.booklink.common.exception.ApiErrorResponses;
 import com.bookbook.booklink.common.exception.BaseResponse;
 import com.bookbook.booklink.common.exception.ErrorCode;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -30,7 +32,8 @@ public interface LibraryApiDocs {
     @PostMapping
     ResponseEntity<BaseResponse<UUID>> registerLibrary(
             @Valid @RequestBody LibraryRegDto libraryRegDto,
-            @RequestHeader("Trace-Id") String traceId
+            @RequestHeader("Trace-Id") String traceId,
+            @AuthenticationPrincipal(expression = "member") Member member
     );
 
     @Operation(
@@ -42,7 +45,8 @@ public interface LibraryApiDocs {
     @PutMapping
     ResponseEntity<BaseResponse<UUID>> updateLibrary(
             @Valid @RequestBody LibraryUpdateDto libraryUpdateDto,
-            @RequestHeader("Trace-Id") String traceId
+            @RequestHeader("Trace-Id") String traceId,
+            @AuthenticationPrincipal(expression = "member") Member member
     );
 
     @Operation(
@@ -53,8 +57,9 @@ public interface LibraryApiDocs {
             ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
     @DeleteMapping("/{id}")
     ResponseEntity<BaseResponse<Boolean>> deleteLibrary(
-            @PathVariable @NotNull UUID id,
-            @RequestHeader("Trace-Id") String traceId
+            @PathVariable @NotNull(message = "수정할 도서관의 ID는 필수입니다.") UUID id,
+            @RequestHeader("Trace-Id") String traceId,
+            @AuthenticationPrincipal(expression = "member") Member member
     );
 
     @Operation(
@@ -65,7 +70,7 @@ public interface LibraryApiDocs {
             ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION, ErrorCode.LIBRARY_NOT_FOUND})
     @GetMapping("/{id}")
     ResponseEntity<BaseResponse<LibraryDetailDto>> getLibrary(
-            @PathVariable @NotNull UUID id
+            @PathVariable @NotNull(message = "조회할 도서관의 ID는 필수입니다.") UUID id
     );
 
     @Operation(

--- a/src/main/java/com/bookbook/booklink/library_service/model/Library.java
+++ b/src/main/java/com/bookbook/booklink/library_service/model/Library.java
@@ -1,5 +1,6 @@
 package com.bookbook.booklink.library_service.model;
 
+import com.bookbook.booklink.auth_service.model.Member;
 import com.bookbook.booklink.book_service.model.LibraryBook;
 import com.bookbook.booklink.library_service.model.dto.request.LibraryRegDto;
 import com.bookbook.booklink.library_service.model.dto.request.LibraryUpdateDto;
@@ -101,21 +102,23 @@ public class Library {
     @Schema(description = "영업 종료 시간", example = "21:00", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalTime endTime;
 
-    // todo: User와 1:1 연결 필요
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false, unique = true)
+    private Member member;
 
     @OneToMany(mappedBy = "library", cascade = CascadeType.ALL, orphanRemoval = true)
     @Schema(description = "도서관이 소장하고 있는 도서들")
     private List<LibraryBook> libraryBooks = new ArrayList<>();
 
-    public static Library toEntity(LibraryRegDto libraryRegDto) {
+    public static Library toEntity(LibraryRegDto libraryRegDto, Member member) {
         return Library.builder()
                 .name(libraryRegDto.getName())
                 .description(libraryRegDto.getDescription())
-                .latitude(13.241400)
-                .longitude(15.414000)   // todo: User에서 위치정보 가져와서 위도 경도 변환해서 넣어야함
+                .latitude(libraryRegDto.getLatitude())
+                .longitude(libraryRegDto.getLongitude())
                 .startTime(libraryRegDto.getStartTime())
                 .endTime(libraryRegDto.getEndTime())
-                //todo: User 연결 추가
+                .member(member)
                 .thumbnailUrl(libraryRegDto.getThumbnailUrl())
                 .build();
     }

--- a/src/main/java/com/bookbook/booklink/library_service/model/dto/request/LibraryRegDto.java
+++ b/src/main/java/com/bookbook/booklink/library_service/model/dto/request/LibraryRegDto.java
@@ -1,9 +1,7 @@
 package com.bookbook.booklink.library_service.model.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import org.hibernate.validator.constraints.URL;
 
@@ -32,6 +30,16 @@ public class LibraryRegDto {
 
     @Schema(description = "도서관 운영 종료 시간 (HH:mm 형식)", type = "string", format = "partial-time", example = "21:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private LocalTime endTime;
+
+    @DecimalMin(value = "-90.0")
+    @DecimalMax(value = "90.0")
+    @Schema(description = "도서관 위도", example = "37.497923", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Double latitude;
+
+    @DecimalMin(value = "-180.0")
+    @DecimalMax(value = "180.0")
+    @Schema(description = "도서관 경도", example = "127.027612", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Double longitude;
 
     @AssertTrue(message = "영업 시작 시간은 종료 시간보다 빨라야 합니다.")
     public boolean isValidOperatingHours() {

--- a/src/main/java/com/bookbook/booklink/library_service/model/dto/response/LibraryDetailDto.java
+++ b/src/main/java/com/bookbook/booklink/library_service/model/dto/response/LibraryDetailDto.java
@@ -1,5 +1,8 @@
 package com.bookbook.booklink.library_service.model.dto.response;
 
+import com.bookbook.booklink.book_service.model.Book;
+import com.bookbook.booklink.book_service.model.BookCategory;
+import com.bookbook.booklink.book_service.model.LibraryBook;
 import com.bookbook.booklink.library_service.model.Library;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -9,7 +12,9 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Data
 @Builder
@@ -47,6 +52,9 @@ public class LibraryDetailDto {
     @Schema(description = "영업 종료 시간", example = "21:00", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalTime endTime;
 
+    @Schema(description = "이 도서관에서 좋아요 수가 높은 상위 5권의 도서")
+    private List<PopularBookDto> topBooks;
+
     public static LibraryDetailDto fromEntity(Library library) {
         return LibraryDetailDto.builder()
                 .id(library.getId())
@@ -60,5 +68,55 @@ public class LibraryDetailDto {
                 .startTime(library.getStartTime())
                 .endTime(library.getEndTime())
                 .build();
+    }
+
+    public static LibraryDetailDto fromEntity(Library library, List<LibraryBook> top5List) {
+        return LibraryDetailDto.builder()
+                .id(library.getId())
+                .name(library.getName())
+                .description(library.getDescription())
+                .stars(library.getStars())
+                .likeCount(library.getLikeCount())
+                .bookCount(library.getBookCount())
+                .createdAt(library.getCreatedAt())
+                .thumbnailUrl(library.getThumbnailUrl())
+                .startTime(library.getStartTime())
+                .topBooks(top5List.stream()
+                        .map(PopularBookDto::from)
+                        .collect(Collectors.toList()))
+                .endTime(library.getEndTime())
+                .build();
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PopularBookDto {
+        @Schema(description = "도서 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+        private UUID bookId;
+
+        @Schema(description = "도서 제목", example = "마흔에 읽는 쇼펜하우어")
+        private String title;
+
+        @Schema(description = "저자명", example = "강용수")
+        private String author;
+
+        @Schema(description = "출판사", example = "유노북스", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1, maxLength = 16)
+        private String publisher;
+
+        @Schema(description = "카테고리", example = "GENERALITIES", requiredMode = Schema.RequiredMode.REQUIRED)
+        private BookCategory category;
+
+        public static PopularBookDto from(LibraryBook libraryBook) {
+            Book book = libraryBook.getBook();
+            return PopularBookDto.builder()
+                    .bookId(libraryBook.getId())
+                    .title(book.getTitle())
+                    .author(book.getAuthor())
+                    .publisher(book.getPublisher())
+                    .category(book.getCategory())
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/bookbook/booklink/library_service/repository/LibraryRepository.java
+++ b/src/main/java/com/bookbook/booklink/library_service/repository/LibraryRepository.java
@@ -15,9 +15,10 @@ public interface LibraryRepository extends JpaRepository<Library, UUID> {
     @Query(value = "SELECT * FROM library " +
             "WHERE (6371 * acos(cos(radians(:lat)) * cos(radians(latitude)) * " +
             "cos(radians(longitude) - radians(:lon)) + " +
-            "sin(radians(:lat)) * sin(radians(latitude)))) < 3",
+            "sin(radians(:lat)) * sin(radians(latitude)))) < 3 " +
+            "AND (:name IS NULL OR name LIKE %:name%)",
             nativeQuery = true)
-    List<Library> findNearbyLibraries(@Param("lat") Double lat, @Param("lon") Double lon);
+    List<Library> findNearbyLibraries(@Param("lat") Double lat, @Param("lon") Double lon, @Param("name") String name);
 
 }
     

--- a/src/main/java/com/bookbook/booklink/library_service/service/LibraryService.java
+++ b/src/main/java/com/bookbook/booklink/library_service/service/LibraryService.java
@@ -148,9 +148,9 @@ public class LibraryService {
      * @return 현재위치로부터 3km 이내의 도서관 정보 리스트
      */
     @Transactional(readOnly = true)
-    public List<LibraryDetailDto> getLibraries(Double lat, Double lng) {
+    public List<LibraryDetailDto> getLibraries(Double lat, Double lng, String name) {
 
-        List<Library> libraries = libraryRepository.findNearbyLibraries(lat, lng);
+        List<Library> libraries = libraryRepository.findNearbyLibraries(lat, lng, name);
 
         return libraries.stream().map(LibraryDetailDto::fromEntity).toList();
     }


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

도서관 목록 조회에 이름으로 검색기능 추가했습니다.

기본으로 내 주위 3km 이내의 도서관을 검색하며 선택적으로 이름으로도 검색이 가능합니다.

### 스크린샷
<img width="1403" height="895" alt="image" src="https://github.com/user-attachments/assets/0d6ad293-ac12-4413-9536-d35ca3c522c0" />


## 🔗 참고 자료
> 관련된 문서, API 스펙, 이슈 링크 등을 추가해주세요.

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

**체크리스트**

- [ ] API 테스트를 통과했나요?
- [ ] API 문서화 도구(Swagger)를 적용했나요?
- [ ] 산출물 업데이트가 필요한 경우 반영했나요?
- [ ] 관련 브랜치 전략 및 머지 대상이 적절하나요?
- [ ] 주요 로직에 적절한 로그/주석이 포함되었나요?
- [ ] 코드 컨벤션을 준수했나요? (파일명, 네이밍, 포맷 등)
