### PR TITLE
🔥 로그인 방식 변경 및 Swagger 문서 로그인 가능 변경

### DIFF
--- a/src/main/java/com/bookbook/booklink/auth_service/controller/AuthController.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/controller/AuthController.java
@@ -1,23 +1,67 @@
 package com.bookbook.booklink.auth_service.controller;
 
 import com.bookbook.booklink.auth_service.controller.docs.AuthApiDocs;
+import com.bookbook.booklink.auth_service.model.dto.request.LoginRequest;
+import com.bookbook.booklink.auth_service.model.dto.response.TokenResDto;
 import com.bookbook.booklink.auth_service.service.AuthService;
 import com.bookbook.booklink.common.dto.BaseResponse;
 import com.bookbook.booklink.common.jwt.CustomUserDetail.CustomUserDetails;
+import com.bookbook.booklink.common.jwt.service.RefreshTokenService;
+import com.bookbook.booklink.common.jwt.util.JWTUtil;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class AuthController implements AuthApiDocs {
 
+    private final AuthenticationManager authenticationManager;
     private final AuthService authService;
+    private final JWTUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
 
     @Override
     public ResponseEntity<BaseResponse<Boolean>> logout(@AuthenticationPrincipal CustomUserDetails user){
         authService.logout(user.getUsername()); // email이 담겨있음
         return ResponseEntity.ok(BaseResponse.success(true));
+    }
+
+    @Override
+    public ResponseEntity<BaseResponse<TokenResDto>> login(@Valid @RequestBody LoginRequest loginRequest){
+
+        // 인증 시도
+        Authentication authentication =
+                authenticationManager.authenticate(
+                        new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword()));
+
+        // 인증 성공 시 사용자 정보/권한 획득
+        String email = authentication.getName();
+
+        // 권한 → JWT role 클레임(OWNER/CUSTOMER)로 정규화
+        String role = authentication.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .map(a -> a.startsWith("ROLE_") ? a.substring(5) : a)
+                .orElse("CUSTOMER");
+
+        //JWT 발급
+        String accessToken = jwtUtil.createAccessToken(email, role);
+        String refreshToken = jwtUtil.createRefreshToken(email);
+
+        // 기존 리프레시 토큰 삭제 후 신규 저장
+        refreshTokenService.saveRefreshToken(email, refreshToken);
+
+        // 헤더 + 바디 동시 반환 (Swagger에서 쓰기 편하도록)
+        return ResponseEntity.ok()
+                .header("Authorization", "Bearer " + accessToken)
+                .body(BaseResponse.success(new TokenResDto(accessToken)));
     }
 }

--- a/src/main/java/com/bookbook/booklink/auth_service/controller/docs/AuthApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/controller/docs/AuthApiDocs.java
@@ -1,5 +1,7 @@
 package com.bookbook.booklink.auth_service.controller.docs;
 
+import com.bookbook.booklink.auth_service.model.dto.request.LoginRequest;
+import com.bookbook.booklink.auth_service.model.dto.response.TokenResDto;
 import com.bookbook.booklink.common.exception.ApiErrorResponses;
 import com.bookbook.booklink.common.dto.BaseResponse;
 import com.bookbook.booklink.common.exception.ErrorCode;
@@ -9,6 +11,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequestMapping("/api/auth")
@@ -24,5 +27,12 @@ public interface AuthApiDocs {
             ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
     @PostMapping("/logout")
     public ResponseEntity<BaseResponse<Boolean>> logout(CustomUserDetails user);
+
+    @Operation(
+            summary = "로그인",
+            description = "이메일/비밀번호로 로그인하고 JWT(Access/Refresh)를 발급합니다."
+    )
+    @PostMapping("/login")
+    public ResponseEntity<BaseResponse<TokenResDto>> login(@RequestBody LoginRequest loginRequest);
 
 }

--- a/src/main/java/com/bookbook/booklink/auth_service/model/dto/request/LoginRequest.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/model/dto/request/LoginRequest.java
@@ -1,15 +1,19 @@
 package com.bookbook.booklink.auth_service.model.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class LoginRequest {
 
     @Schema(description = "사용자 이메일", example = "test@test.com")
     private String email;
+
     @Schema(description = "사용자 비밀번호", example = "ghdrlfehd@gmail.com")
     private String password;
 }

--- a/src/main/java/com/bookbook/booklink/auth_service/model/dto/request/LoginRequest.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/model/dto/request/LoginRequest.java
@@ -11,9 +11,9 @@ import lombok.Setter;
 @AllArgsConstructor
 public class LoginRequest {
 
-    @Schema(description = "사용자 이메일", example = "test@test.com")
+    @Schema(description = "사용자 이메일", example = "test1@example.com")
     private String email;
 
-    @Schema(description = "사용자 비밀번호", example = "ghdrlfehd@gmail.com")
+    @Schema(description = "사용자 비밀번호", example = "Piltopgkm@1818")
     private String password;
 }

--- a/src/main/java/com/bookbook/booklink/auth_service/model/dto/response/TokenResDto.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/model/dto/response/TokenResDto.java
@@ -1,0 +1,13 @@
+package com.bookbook.booklink.auth_service.model.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResDto {
+
+    @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
+    private String accessToken;
+}

--- a/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
+++ b/src/main/java/com/bookbook/booklink/book_service/service/LibraryBookService.java
@@ -2,6 +2,7 @@ package com.bookbook.booklink.book_service.service;
 
 import com.bookbook.booklink.book_service.model.Book;
 import com.bookbook.booklink.book_service.model.LibraryBook;
+import com.bookbook.booklink.book_service.model.LibraryBookCopy;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookRegisterDto;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookSearchReqDto;
 import com.bookbook.booklink.book_service.model.dto.request.LibraryBookUpdateDto;

--- a/src/main/java/com/bookbook/booklink/common/config/SwaggerConfig.java
+++ b/src/main/java/com/bookbook/booklink/common/config/SwaggerConfig.java
@@ -1,7 +1,11 @@
 package com.bookbook.booklink.common.config;
 
+
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,6 +19,17 @@ public class SwaggerConfig {
                         .title("BookLink API")
                         .version("v1.0.0")
                         .description("BookLink의 REST API 문서입니다.")
+                )
+                // 🔒 전역 보안 스키마 등록
+                .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+                .components(new Components()
+                        .addSecuritySchemes("Bearer Authentication",
+                                new SecurityScheme()
+                                        .name("Authorization")
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
                 );
     }
 

--- a/src/main/java/com/bookbook/booklink/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/bookbook/booklink/common/config/security/SecurityConfig.java
@@ -45,24 +45,24 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
-        JwtAuthenticationFilter jwtAuthenticationFilter =
-                new JwtAuthenticationFilter(authenticationManager, jwtUtil, refreshTokenService);
-        jwtAuthenticationFilter.setFilterProcessesUrl("/api/login"); // 로그인 URL 지정
+    public SecurityFilterChain securityFilterChain(
+            HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
 
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/member/signup", "/api/login", "/api/token/reissue").permitAll()
+                        // 컨트롤러 기반 로그인/토큰 재발급/회원가입 허용
+                        .requestMatchers("/api/member/signup", "/api/auth/login", "/api/token/reissue").permitAll()
+                        // Swagger 문서 허용
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
+                        // 정적/웹소켓 등 허용
                         .requestMatchers(
                                 "/chat-test.html", "/ws/**", "/favicon.ico",
                                 "/css/**", "/js/**", "/images/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilter(jwtAuthenticationFilter)
                 .addFilterBefore(new JwtAuthorizationFilter(jwtUtil, userDetailsService),
                         UsernamePasswordAuthenticationFilter.class)
 


### PR DESCRIPTION
## 📝작업 내용
sparkles feat(auth) Switch login from security filter to REST API con
troller
- securityFilterChain으로 로그인 하던 방식을 
  RestApi를 통해 로그인 하도록 변경하였습니다.
- 또한, Swagger 문서에서 로그인 가능하도록 SwaggerConfig를 수정하였습니다.
### 스크린샷

## 🔗 참고 자료
<img width="1045" height="807" alt="스크린샷 2025-10-02 010050" src="https://github.com/user-attachments/assets/140cd39d-07a0-4c28-950f-01f9617faa8f" />

## 💬리뷰 요구사항
브랜치 명을 잘못 설정하였는데 이상없을 시 바로 merge 하면 될 것 같습니다.

**체크리스트**

- [ ] API 테스트를 통과했나요?
- [ ] API 문서화 도구(Swagger)를 적용했나요?
- [ ] 산출물 업데이트가 필요한 경우 반영했나요?
- [ ] 관련 브랜치 전략 및 머지 대상이 적절하나요?
- [ ] 주요 로직에 적절한 로그/주석이 포함되었나요?
- [ ] 코드 컨벤션을 준수했나요? (파일명, 네이밍, 포맷 등)
