### PR TITLE
Member엔티티 오류 수정 및 프론트요청 응답 형식 추가

### DIFF
--- a/src/main/java/com/bookbook/booklink/auth_service/controller/EmailVerificationController.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/controller/EmailVerificationController.java
@@ -1,6 +1,5 @@
 package com.bookbook.booklink.auth_service.controller;
 
-import com.bookbook.booklink.auth_service.code.EmailPurpose;
 import com.bookbook.booklink.auth_service.controller.docs.EmailApiDocs;
 import com.bookbook.booklink.auth_service.model.dto.request.SendCodeReqDto;
 import com.bookbook.booklink.auth_service.model.dto.request.VerifyCodeReqDto;
@@ -12,9 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping
+@RestController
 @RequiredArgsConstructor
 public class EmailVerificationController implements EmailApiDocs {
 

--- a/src/main/java/com/bookbook/booklink/auth_service/model/Member.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/model/Member.java
@@ -133,8 +133,13 @@ public class Member {
             orphanRemoval = true)
     private Point point;
 
+    public Member linkPoint(Point point) {
+        this.point = point;
+        return this;
+    }
+
     public static Member ofLocalSignup(SignUpReqDto req, String encodedPassword) {
-        return Member.builder()
+        Member member = Member.builder()
                 .email(req.getEmail())
                 .password(encodedPassword)
                 .name(req.getName())
@@ -146,6 +151,11 @@ public class Member {
                 .role(Role.CUSTOMER)
                 .status(Status.ACTIVE)
                 .build();
+        Point point = Point.builder()
+                .member(member)
+                .balance(0)
+                .build();
+        return member.linkPoint(point);
     }
 
     /**

--- a/src/main/java/com/bookbook/booklink/auth_service/repository/MemberRepository.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/repository/MemberRepository.java
@@ -11,5 +11,6 @@ import com.bookbook.booklink.auth_service.model.Member;
 public interface MemberRepository extends JpaRepository<Member, UUID> {
     boolean existsByEmail(String email);
     Optional<Member> findByEmail(String email);
+    boolean existsByNickname(String nickname);
 }
     

--- a/src/main/java/com/bookbook/booklink/auth_service/service/MemberService.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/service/MemberService.java
@@ -51,6 +51,10 @@ public class MemberService {
         if (memberRepository.existsByEmail(signUpReqDto.getEmail())) {
             throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
+        if (memberRepository.existsByNickname(signUpReqDto.getNickname())) {
+            throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+
         String encodedPassword = passwordEncoder.encode(signUpReqDto.getPassword());
 
         // Library 엔티티 생성 후 DB 저장

--- a/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
+++ b/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
@@ -35,7 +35,10 @@ public enum ErrorCode {
     PASSWORD_POLICY_INVALID(HttpStatus.BAD_REQUEST, "PASSWORD_POLICY_INVALID_400", "비밀번호는 대/소문자·숫자·특수문자 각 1자 이상 포함, 공백 불가"),
 
     @Schema(description = "이미 등록된 이메일입니다.")
-    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "EMAIL_ALREADY_EXISTS_409", "이미 등록된 이메일입니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "EMAIL_ALREADY_EXISTS_400", "이미 등록된 이메일입니다."),
+
+    @Schema(description = "이미 등록된 닉네임입니다.")
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "NICKNAME_ALREADY_EXISTS_409", "이미 등록된 닉네임입니다."),
 
     @Schema(description = "사용자를 찾을 수 없습니다.")
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND_404", "사용자를 찾을 수 없습니다.."),


### PR DESCRIPTION
## 📝작업 내용
- 이전 Member엔티티에 존재하는 point_balance가 존재하고 회원가입 시 point의 기본 값이 설정이 되지 않아 수정하였습니다.
- 회원 가입 시 닉네임 중복 검증이 존재하지 않아 수정하였습니다.
- 이전 기능 개발 시(이메일 인증) 관련 테스트를 진행하여 여기에 스크린샷을 올렸습니다.

### 스크린샷

## 🔗 참고 자료
[비밀번호 재설정]
<img width="572" height="400" alt="image" src="https://github.com/user-attachments/assets/9bcae8c2-579e-490d-80de-07b90a255f92" />
---

[인증코드]
<img width="347" height="229" alt="image" src="https://github.com/user-attachments/assets/abdc8d94-58fa-4637-8b25-6c5f8cae5c7f" />
---
[검증]
- 실패
<img width="841" height="565" alt="image" src="https://github.com/user-attachments/assets/c944ac89-eb74-4c43-b0dd-48c42d4dcf91" />
- 성공
<img width="797" height="586" alt="image" src="https://github.com/user-attachments/assets/d69cb9b7-e7a4-4f85-82da-0a964d16c408" />


## 💬리뷰 요구사항
Member에 연관관계 맺어진 Point 엔티티 중 회원 가입 시 기본 balance가 0으로 설정되도록 수정하였는데
이게 이렇게 구현하는게 맞는건지 아니면 기본으로 0으로 설정되도록 하신건지 확인 부탁드립니다!


- [ ] API 테스트를 통과했나요?
- [ ] API 문서화 도구(Swagger)를 적용했나요?
- [ ] 산출물 업데이트가 필요한 경우 반영했나요?
- [ ] 관련 브랜치 전략 및 머지 대상이 적절하나요?
- [ ] 주요 로직에 적절한 로그/주석이 포함되었나요?
- [ ] 코드 컨벤션을 준수했나요? (파일명, 네이밍, 포맷 등)
