### PR TITLE
회원 탈퇴 기능

### DIFF
--- a/src/main/java/com/bookbook/booklink/auth_service/code/EmailPurpose.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/code/EmailPurpose.java
@@ -1,5 +1,0 @@
-package com.bookbook.booklink.auth_service.code;
-
-public enum EmailPurpose {
-    REGISTER, RESET_PASSWORD
-}

--- a/src/main/java/com/bookbook/booklink/auth_service/code/Status.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/code/Status.java
@@ -1,8 +1,6 @@
 package com.bookbook.booklink.auth_service.code;
 
 public enum Status {
-    //TODO
-    // 회원상태 어떤거 있을 지
     ACTIVE,
     DEACTIVATED
 }

--- a/src/main/java/com/bookbook/booklink/auth_service/controller/AuthController.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/controller/AuthController.java
@@ -6,17 +6,11 @@ import com.bookbook.booklink.auth_service.model.dto.response.TokenResDto;
 import com.bookbook.booklink.auth_service.service.AuthService;
 import com.bookbook.booklink.common.dto.BaseResponse;
 import com.bookbook.booklink.common.jwt.CustomUserDetail.CustomUserDetails;
-import com.bookbook.booklink.common.jwt.service.RefreshTokenService;
-import com.bookbook.booklink.common.jwt.util.JWTUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,10 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController implements AuthApiDocs {
 
-    private final AuthenticationManager authenticationManager;
     private final AuthService authService;
-    private final JWTUtil jwtUtil;
-    private final RefreshTokenService refreshTokenService;
 
     @Override
     public ResponseEntity<BaseResponse<Boolean>> logout(@AuthenticationPrincipal CustomUserDetails user){
@@ -51,30 +42,10 @@ public class AuthController implements AuthApiDocs {
     @Override
     public ResponseEntity<BaseResponse<TokenResDto>> login(@Valid @RequestBody LoginReqDto loginReqDto){
 
-        // 인증 시도
-        Authentication authentication =
-                authenticationManager.authenticate(
-                        new UsernamePasswordAuthenticationToken(loginReqDto.getEmail(), loginReqDto.getPassword()));
-
-        // 인증 성공 시 사용자 정보/권한 획득
-        String email = authentication.getName();
-
-        // 권한 → JWT role 클레임(OWNER/CUSTOMER)로 정규화
-        String role = authentication.getAuthorities().stream()
-                .findFirst()
-                .map(GrantedAuthority::getAuthority)
-                .map(a -> a.startsWith("ROLE_") ? a.substring(5) : a)
-                .orElse("CUSTOMER");
-
-        //JWT 발급
-        String accessToken = jwtUtil.createAccessToken(email, role);
-        String refreshToken = jwtUtil.createRefreshToken(email);
-
-        // 기존 리프레시 토큰 삭제 후 신규 저장
-        refreshTokenService.saveRefreshToken(email, refreshToken);
+        AuthService.LoginResult loginResult = authService.login(loginReqDto);
 
         // HttpOnly RefreshToken 쿠키 생성
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", refreshToken)
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken",loginResult.refreshToken())
                 .httpOnly(true)
                 .secure(false)
                 .path("/")
@@ -84,6 +55,6 @@ public class AuthController implements AuthApiDocs {
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-                .body(BaseResponse.success(new TokenResDto(accessToken)));
+                .body(BaseResponse.success(new TokenResDto(loginResult.accessToken())));
     }
 }

--- a/src/main/java/com/bookbook/booklink/auth_service/controller/MemberController.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.bookbook.booklink.auth_service.controller;
 
 import com.bookbook.booklink.auth_service.model.dto.request.PasswordCheckReqDto;
+import com.bookbook.booklink.auth_service.model.dto.response.DeactivateResDto;
 import com.bookbook.booklink.auth_service.service.PasswordCheckService;
 import com.bookbook.booklink.common.dto.BaseResponse;
 import com.bookbook.booklink.common.jwt.CustomUserDetail.CustomUserDetails;
@@ -66,6 +67,17 @@ public class MemberController implements MemberApiDocs {
         Boolean matches = passwordCheckService.verifyPassword(user.getMember().getEmail(), passwordCheckReqDto.getPassword());
         return ResponseEntity.ok()
                 .body(BaseResponse.success(matches));
+    }
+
+    @Override
+    public ResponseEntity<BaseResponse<DeactivateResDto>> deactivateMe(
+            @AuthenticationPrincipal CustomUserDetails user
+    ){
+        UUID memberId = user.getMember().getId();
+        DeactivateResDto response = memberService.deactivateMember(memberId);
+
+        return ResponseEntity.ok()
+                .body(BaseResponse.success(response));
     }
 }
     

--- a/src/main/java/com/bookbook/booklink/auth_service/controller/docs/AuthApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/controller/docs/AuthApiDocs.java
@@ -9,13 +9,14 @@ import com.bookbook.booklink.common.jwt.CustomUserDetail.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequestMapping("/api/auth")
-@Tag(name = "로그아웃 API", description = "로그아웃관련 RefreshToken 제거 API")
+@Tag(name = "Auth API", description = "인증/인가 관련 API")
 public interface AuthApiDocs {
 
     @Operation(
@@ -33,6 +34,6 @@ public interface AuthApiDocs {
             description = "이메일/비밀번호로 로그인하고 JWT(Access/Refresh)를 발급합니다."
     )
     @PostMapping("/login")
-    public ResponseEntity<BaseResponse<TokenResDto>> login(@RequestBody LoginReqDto loginReqDto);
+    public ResponseEntity<BaseResponse<TokenResDto>> login(@Valid @RequestBody LoginReqDto loginReqDto);
 
 }

--- a/src/main/java/com/bookbook/booklink/auth_service/controller/docs/MemberApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/controller/docs/MemberApiDocs.java
@@ -1,15 +1,16 @@
 package com.bookbook.booklink.auth_service.controller.docs;
 
 import com.bookbook.booklink.auth_service.model.dto.request.PasswordCheckReqDto;
-import com.bookbook.booklink.auth_service.model.dto.request.PasswordResetReqDto;
-import com.bookbook.booklink.common.exception.ApiErrorResponses;
-import com.bookbook.booklink.common.dto.BaseResponse;
-import com.bookbook.booklink.common.exception.ErrorCode;
-import com.bookbook.booklink.common.jwt.CustomUserDetail.CustomUserDetails;
 import com.bookbook.booklink.auth_service.model.dto.request.SignUpReqDto;
 import com.bookbook.booklink.auth_service.model.dto.request.UpdateReqDto;
+import com.bookbook.booklink.auth_service.model.dto.response.DeactivateResDto;
 import com.bookbook.booklink.auth_service.model.dto.response.ProfileResDto;
+import com.bookbook.booklink.common.dto.BaseResponse;
+import com.bookbook.booklink.common.exception.ApiErrorResponses;
+import com.bookbook.booklink.common.exception.ErrorCode;
+import com.bookbook.booklink.common.jwt.CustomUserDetail.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -65,5 +66,15 @@ public interface MemberApiDocs {
     public ResponseEntity<BaseResponse<Boolean>> checkPassword(
             @Valid @RequestBody PasswordCheckReqDto passwordCheckReqDto,
             @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
+            summary = "회원 탈퇴(계정 비활성화)",
+            description = "현재 로그인한 사용자의 계정을 비활성화(소프트 삭제)합니다."
+    )
+    @ApiErrorResponses({ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.MEMBER_ALREADY_INACTIVE})
+    @DeleteMapping("/deactivate")
+    ResponseEntity<BaseResponse<DeactivateResDto>> deactivateMe(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user
     );
 }

--- a/src/main/java/com/bookbook/booklink/auth_service/model/Member.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/model/Member.java
@@ -133,13 +133,8 @@ public class Member {
             orphanRemoval = true)
     private Point point;
 
-    public Member linkPoint(Point point) {
-        this.point = point;
-        return this;
-    }
-
     public static Member ofLocalSignup(SignUpReqDto req, String encodedPassword) {
-        Member member = Member.builder()
+        return Member.builder()
                 .email(req.getEmail())
                 .password(encodedPassword)
                 .name(req.getName())
@@ -151,11 +146,6 @@ public class Member {
                 .role(Role.CUSTOMER)
                 .status(Status.ACTIVE)
                 .build();
-        Point point = Point.builder()
-                .member(member)
-                .balance(0)
-                .build();
-        return member.linkPoint(point);
     }
 
     /**

--- a/src/main/java/com/bookbook/booklink/auth_service/model/Member.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/model/Member.java
@@ -133,6 +133,11 @@ public class Member {
             orphanRemoval = true)
     private Point point;
 
+    // ✅ 언제까지 다시 로그인하면 복구 가능한지
+    @Schema(description = "재활성화 가능 마감일", example = "2025-11-06" +
+            "T23:59:59")
+    private LocalDateTime reactivatableUntil;
+
     public static Member ofLocalSignup(SignUpReqDto req, String encodedPassword) {
         return Member.builder()
                 .email(req.getEmail())
@@ -161,5 +166,34 @@ public class Member {
 
     public void changePassword(String encodedPassword){
         this.password = encodedPassword;
+    }
+
+    /**
+     * 계정 비활성화(소프트 탈퇴)
+     * @param reactivatableDays 다시 로그인하면 복구 가능한 일 수 (예: 365일)
+     */
+    public void deactivate(long reactivatableDays) {
+        this.status = Status.DEACTIVATED;
+        this.deletedAt = LocalDateTime.now();
+        this.reactivatableUntil = this.deletedAt.plusDays(reactivatableDays);
+    }
+
+    /** 계정 재활성화 */
+    public void reactivate() {
+        this.status = Status.ACTIVE;
+        this.deletedAt = null;
+        this.reactivatableUntil = null;
+    }
+
+    /** 현재 비활성 상태인지 여부 */
+    public boolean isDeactivated() {
+        return this.status == Status.DEACTIVATED;
+    }
+
+    /** 지금 시점에 재활성화가 가능한지 여부 */
+    public boolean canReactivate() {
+        return this.isDeactivated()
+                && this.reactivatableUntil != null
+                && LocalDateTime.now().isBefore(this.reactivatableUntil);
     }
 }

--- a/src/main/java/com/bookbook/booklink/auth_service/model/dto/response/DeactivateResDto.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/model/dto/response/DeactivateResDto.java
@@ -1,0 +1,21 @@
+package com.bookbook.booklink.auth_service.model.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "회원 탈퇴(비활성화) 응답 DTO")
+public class DeactivateResDto {
+
+    @Schema(description = "비활성화 처리 성공 여부", example = "true")
+    private boolean success;
+
+    @Schema(description = "재활성화 가능 마감일", example = "2025-11-06T23:59:59")
+    private LocalDateTime reactivatableUntil;
+}

--- a/src/main/java/com/bookbook/booklink/auth_service/service/AuthService.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/service/AuthService.java
@@ -1,6 +1,10 @@
 package com.bookbook.booklink.auth_service.service;
 
+import com.bookbook.booklink.auth_service.model.Member;
 import com.bookbook.booklink.auth_service.model.dto.request.LoginReqDto;
+import com.bookbook.booklink.auth_service.repository.MemberRepository;
+import com.bookbook.booklink.common.exception.CustomException;
+import com.bookbook.booklink.common.exception.ErrorCode;
 import com.bookbook.booklink.common.jwt.service.RefreshTokenService;
 import com.bookbook.booklink.common.jwt.util.JWTUtil;
 import lombok.AllArgsConstructor;
@@ -19,6 +23,7 @@ public class AuthService {
     private final RefreshTokenService refreshTokenService;
     private final AuthenticationManager authenticationManager;
     private final JWTUtil jwtUtil;
+    private final MemberRepository memberRepository;
 
     public void logout(String email) {
         refreshTokenService.logout(email);
@@ -37,6 +42,18 @@ public class AuthService {
 
         // 인증 성공 시 이메일/권한 획득
         String email = authentication.getName();
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 3. 비활성 계정 복구/차단 로직
+        if (member.canReactivate()) {
+            // 아직 복구 가능 기간 이내의 비활성 계정 → 자동 ACTIVE로 복구
+            member.reactivate();
+        } else if (member.isDeactivated()) {
+            // 복구 기간도 지났는데 여전히 비활성 → 로그인 차단
+            throw new CustomException(ErrorCode.MEMBER_DEACTIVATED);
+        }
 
         // 권한 → JWT role 클레임(OWNER/CUSTOMER)로 정규화
         String role = authentication.getAuthorities().stream()

--- a/src/main/java/com/bookbook/booklink/auth_service/service/AuthService.java
+++ b/src/main/java/com/bookbook/booklink/auth_service/service/AuthService.java
@@ -1,15 +1,61 @@
 package com.bookbook.booklink.auth_service.service;
 
+import com.bookbook.booklink.auth_service.model.dto.request.LoginReqDto;
 import com.bookbook.booklink.common.jwt.service.RefreshTokenService;
+import com.bookbook.booklink.common.jwt.util.JWTUtil;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
     private final RefreshTokenService refreshTokenService;
+    private final AuthenticationManager authenticationManager;
+    private final JWTUtil jwtUtil;
 
     public void logout(String email) {
         refreshTokenService.logout(email);
     }
+
+    public LoginResult login(LoginReqDto loginReqDto) {
+
+        // 인증 시도
+        Authentication authentication =
+                authenticationManager.authenticate(
+                        new UsernamePasswordAuthenticationToken(
+                                loginReqDto.getEmail(),
+                                loginReqDto.getPassword()
+                        )
+                );
+
+        // 인증 성공 시 이메일/권한 획득
+        String email = authentication.getName();
+
+        // 권한 → JWT role 클레임(OWNER/CUSTOMER)로 정규화
+        String role = authentication.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .map(a -> a.startsWith("ROLE_") ? a.substring(5) : a)
+                .orElse("CUSTOMER");
+
+        // JWT 발급
+        String accessToken = jwtUtil.createAccessToken(email, role);
+        String refreshToken = jwtUtil.createRefreshToken(email);
+
+        // 4. 기존 리프레시 토큰 삭제 후 신규 저장
+        refreshTokenService.saveRefreshToken(email, refreshToken);
+
+        // 5. 컨트롤러에서 쓸 수 있도록 두 토큰을 같이 반환
+        return new LoginResult(accessToken, refreshToken);
+    }
+
+    // RefreshToken을 body에 담지 않게 하기 위한 recode 구조
+    public record LoginResult(String accessToken, String refreshToken) { }
 }

--- a/src/main/java/com/bookbook/booklink/chat_service/single/controller/SingleChatsController.java
+++ b/src/main/java/com/bookbook/booklink/chat_service/single/controller/SingleChatsController.java
@@ -38,6 +38,15 @@ public class SingleChatsController implements SingleChatApiDocs {
     }
 
     @Override
+    public ResponseEntity<BaseResponse<List<SingleRoomResDto>>> getMyRooms(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        UUID me = user.getMember().getId();
+        List<SingleRoomResDto> rooms = singleChatsService.getMyRooms(me);
+        return ResponseEntity.ok(BaseResponse.success(rooms));
+    }
+
+    @Override
     public ResponseEntity<BaseResponse<MessageResDto>> sendMessage(
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestBody MessageReqDto dto

--- a/src/main/java/com/bookbook/booklink/chat_service/single/controller/SingleChatsController.java
+++ b/src/main/java/com/bookbook/booklink/chat_service/single/controller/SingleChatsController.java
@@ -26,10 +26,14 @@ public class SingleChatsController implements SingleChatApiDocs {
 
     @Override
     public ResponseEntity<BaseResponse<SingleRoomResDto>> createOrGetRoom(
-            @RequestBody SingleRoomReqDto reqDto
+            @RequestBody SingleRoomReqDto reqDto,
+            @AuthenticationPrincipal CustomUserDetails user
     ) {
+        UUID me = user.getMember().getId();
+        UUID chatPartner = reqDto.getChatPartner();
+
         SingleRoomResDto response =
-                singleChatsService.getOrCreateChatRoom(reqDto);
+                singleChatsService.getOrCreateChatRoom(me,chatPartner);
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 

--- a/src/main/java/com/bookbook/booklink/chat_service/single/controller/docs/SingleChatApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/chat_service/single/controller/docs/SingleChatApiDocs.java
@@ -34,6 +34,18 @@ public interface SingleChatApiDocs {
     );
 
     @Operation(
+            summary = "내 1:1 채팅방 모든 목록 조회",
+            description = "로그인한 사용자가 참여 중인 1:1 채팅방 목록들을 반환합니다."
+    )
+    @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
+            ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
+    @GetMapping("/rooms")
+    ResponseEntity<BaseResponse<List<SingleRoomResDto>>> getMyRooms(
+            @AuthenticationPrincipal CustomUserDetails user
+    );
+
+
+    @Operation(
             summary = "메시지 보내기",
             description = "특정 채팅방에 메시지를 전송합니다."
     )

--- a/src/main/java/com/bookbook/booklink/chat_service/single/controller/docs/SingleChatApiDocs.java
+++ b/src/main/java/com/bookbook/booklink/chat_service/single/controller/docs/SingleChatApiDocs.java
@@ -27,9 +27,10 @@ public interface SingleChatApiDocs {
     )
     @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
             ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
-    @PostMapping("/rooms")
+    @PostMapping("/room")
     public ResponseEntity<BaseResponse<SingleRoomResDto>> createOrGetRoom(
-            @RequestBody SingleRoomReqDto dto
+            @RequestBody SingleRoomReqDto dto,
+            @AuthenticationPrincipal CustomUserDetails user
     );
 
     @Operation(
@@ -49,7 +50,7 @@ public interface SingleChatApiDocs {
     )
     @ApiErrorResponses({ErrorCode.VALIDATION_FAILED, ErrorCode.DATABASE_ERROR,
             ErrorCode.METHOD_UNAUTHORIZED, ErrorCode.DATA_INTEGRITY_VIOLATION})
-    @GetMapping("/rooms/{chatId}/messages")
+    @GetMapping("/room/{chatId}/messages")
     public ResponseEntity<BaseResponse<List<MessageResDto>>> getMessages(
             @PathVariable UUID chatId);
 }

--- a/src/main/java/com/bookbook/booklink/chat_service/single/model/SingleChats.java
+++ b/src/main/java/com/bookbook/booklink/chat_service/single/model/SingleChats.java
@@ -43,10 +43,10 @@ public class SingleChats {
     @Schema(description = "생성 시각", example = "2025-09-28T15:00:00")
     private LocalDateTime createdAt;
 
-    @Schema(description = "참여자 1 ID", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+    @Schema(description = "생성자 ID", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
     private UUID user1Id;
 
-    @Schema(description = "참여자 2 ID", example = "7fa85f64-5717-4562-b3fc-2c963f66afa6")
+    @Schema(description = "참여자 ID", example = "7fa85f64-5717-4562-b3fc-2c963f66afa6")
     private UUID user2Id;
 
     public static SingleChats createNormalized(UUID a, UUID b) {

--- a/src/main/java/com/bookbook/booklink/chat_service/single/model/dto/request/SingleRoomReqDto.java
+++ b/src/main/java/com/bookbook/booklink/chat_service/single/model/dto/request/SingleRoomReqDto.java
@@ -11,9 +11,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SingleRoomReqDto {
-    @Schema(description = "참여자 1 ID", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
-    private UUID user1Id;
 
     @Schema(description = "참여자 2 ID", example = "7fa85f64-5717-4562-b3fc-2c963f66afa6")
-    private UUID user2Id;
+    private UUID chatPartner;
 }

--- a/src/main/java/com/bookbook/booklink/chat_service/single/model/dto/response/SingleRoomResDto.java
+++ b/src/main/java/com/bookbook/booklink/chat_service/single/model/dto/response/SingleRoomResDto.java
@@ -42,8 +42,8 @@ public class SingleRoomResDto {
     public static SingleRoomResDto fromEntity(SingleChats chat) {
         return SingleRoomResDto.builder()
                 .chatId(chat.getId())
-                .user1Id(chat.getMe())
-                .user2Id(chat.getChatPartner())
+                .user1Id(chat.getUser1Id())
+                .user2Id(chat.getUser2Id())
                 .lastMessage(chat.getLastMessage())
                 .lastSentAt(chat.getLastSentAt())
                 .createdAt(chat.getCreatedAt())

--- a/src/main/java/com/bookbook/booklink/chat_service/single/model/dto/response/SingleRoomResDto.java
+++ b/src/main/java/com/bookbook/booklink/chat_service/single/model/dto/response/SingleRoomResDto.java
@@ -42,8 +42,8 @@ public class SingleRoomResDto {
     public static SingleRoomResDto fromEntity(SingleChats chat) {
         return SingleRoomResDto.builder()
                 .chatId(chat.getId())
-                .user1Id(chat.getUser1Id())
-                .user2Id(chat.getUser2Id())
+                .user1Id(chat.getMe())
+                .user2Id(chat.getChatPartner())
                 .lastMessage(chat.getLastMessage())
                 .lastSentAt(chat.getLastSentAt())
                 .createdAt(chat.getCreatedAt())

--- a/src/main/java/com/bookbook/booklink/chat_service/single/repository/SingleChatsRepository.java
+++ b/src/main/java/com/bookbook/booklink/chat_service/single/repository/SingleChatsRepository.java
@@ -2,14 +2,27 @@ package com.bookbook.booklink.chat_service.single.repository;
 
 import com.bookbook.booklink.chat_service.single.model.SingleChats;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface SingleChatsRepository extends JpaRepository<SingleChats, UUID> {
-    // 두 유저간의 채팅방이 이미 있는지 확인
+    /**
+     * 두 유저 간 채팅방이 이미 존재하는지 확인
+     */
     Optional<SingleChats> findByUser1IdAndUser2Id(UUID user1Id, UUID user2Id);
+
+    /**
+     * 유저가 참여한 채팅방을 마지막 메시지 시각 기준으로 내림차순 정렬
+     */
+    @Query("SELECT s FROM SingleChats s " +
+            "WHERE s.user1Id = :id OR s.user2Id = :id " +
+            "ORDER BY s.lastSentAt DESC NULLS LAST")
+    List<SingleChats> findAllByMemberSorted(@Param("id") UUID memberId);
 }
     

--- a/src/main/java/com/bookbook/booklink/chat_service/single/service/SingleChatsService.java
+++ b/src/main/java/com/bookbook/booklink/chat_service/single/service/SingleChatsService.java
@@ -30,16 +30,14 @@ public class SingleChatsService {
      * - user1-user2, user2-user1 조합을 모두 확인합니다. <br>
      * - 기존 채팅방이 없을 경우 새로 생성 후 저장합니다.
      *
-     * @param dto 채팅방 생성 요청 DTO (user1Id, user2Id 포함)
+     * @param me 채팅방 생성 요청 DTO (user1Id, user2Id 포함)
      * @return 생성되었거나 조회된 채팅방 응답 DTO
      */
     @Transactional
-    public SingleRoomResDto getOrCreateChatRoom(SingleRoomReqDto dto) {
+    public SingleRoomResDto getOrCreateChatRoom(UUID me, UUID chatPartner) {
 
-        UUID a = dto.getUser1Id();
-        UUID b = dto.getUser2Id();
-        UUID u1 = a.compareTo(b) <= 0 ? a : b;
-        UUID u2 = a.compareTo(b) <= 0 ? b : a;
+        UUID u1 = me.compareTo(chatPartner) <= 0 ? me : chatPartner;
+        UUID u2 = me.compareTo(chatPartner) <= 0 ? chatPartner : me;
 
         SingleChats chat = singleChatsRepository.findByUser1IdAndUser2Id(u1, u2)
                 .orElseGet(() -> singleChatsRepository.save(SingleChats.createNormalized(u1, u2)));

--- a/src/main/java/com/bookbook/booklink/chat_service/single/service/SingleChatsService.java
+++ b/src/main/java/com/bookbook/booklink/chat_service/single/service/SingleChatsService.java
@@ -36,6 +36,10 @@ public class SingleChatsService {
     @Transactional
     public SingleRoomResDto getOrCreateChatRoom(UUID me, UUID chatPartner) {
 
+        if (me == null || chatPartner == null) {
+            throw new CustomException(ErrorCode.CHAT_ROOM_INVALID_MEMBER);
+        }
+
         UUID u1 = me.compareTo(chatPartner) <= 0 ? me : chatPartner;
         UUID u2 = me.compareTo(chatPartner) <= 0 ? chatPartner : me;
 
@@ -45,6 +49,15 @@ public class SingleChatsService {
         return SingleRoomResDto.fromEntity(chat);
     }
 
+    @Transactional(readOnly = true)
+    public List<SingleRoomResDto> getMyRooms(UUID memberId) {
+        List<SingleChats> rooms =
+                singleChatsRepository.findAllByMemberSorted(memberId);
+
+        return rooms.stream()
+                .map(SingleRoomResDto::fromEntity)
+                .toList();
+    }
 
 
     @Transactional

--- a/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
+++ b/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
@@ -74,6 +74,8 @@ public enum ErrorCode {
     CHAT_ROOM_FORBIDDEN(HttpStatus.FORBIDDEN, "CHAT_ROOM_FORBIDDEN_400", "채팅방 참여자가 아닙니다."),
     CHAT_ROOM_CREATE_CONFLICT(HttpStatus.CONFLICT, "CHAT_ROOM_CREATE_CONFLICT_400", "동일한 채팅방이 이미 존재합니다."),
     MESSAGE_SENDER_MISMATCH(HttpStatus.BAD_REQUEST, "MESSAGE_SENDER_MISMATCH_400", "보내는 사용자 정보가 유효하지 않습니다."),
+    CHAT_ROOM_INVALID_MEMBER(HttpStatus.BAD_REQUEST, "CHAT_ROOM_INVALID_MEMBER_400", "채팅방 생성 시 유효하지 않은 사용자 정보입니다."),
+
     /*
      * Library
      */

--- a/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
+++ b/src/main/java/com/bookbook/booklink/common/exception/ErrorCode.java
@@ -197,7 +197,13 @@ public enum ErrorCode {
     PASSWORD_RESET_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "PASSWORD_RESET_TOKEN_EXPIRED_400", "비밀번호 재설정 링크가 만료되었습니다."),
     PASSWORD_CONFIRM_NOT_MATCH(HttpStatus.BAD_REQUEST, "PASSWORD_CONFIRM_NOT_MATCH_400", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
     PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "PASSWORD_SAME_AS_OLD_400", "기존 비밀번호와 다른 비밀번호를 사용해 주세요."),
-    ;
+
+    // 회원 탈퇴
+    @Schema(description = "이미 비활성화된 회원입니다.")
+    MEMBER_ALREADY_INACTIVE(HttpStatus.BAD_REQUEST, "MEMBER_ALREADY_INACTIVE_400", "이미 비활성화된 회원입니다."),
+
+    @Schema(description = "비활성화된 계정입니다.")
+    MEMBER_DEACTIVATED(HttpStatus.UNAUTHORIZED, "MEMBER_DEACTIVATED_401", "비활성화된 계정입니다.");
 
     private final HttpStatus httpStatus;
     @Schema(description = "에러 코드", example = "UNKNOWN_ERROR_500", implementation = ErrorCode.class)


### PR DESCRIPTION
## 📝작업 내용
회원 탈퇴 기능을 구현하였습니다.
- ✨ feat: impelements DeactiveatedAPI
: 회원 탈퇴 API 구현
- ♻️ refactor: Move login logic from controller to service layer
: 로그인 시 컨트롤러에 있던 기능을 service레이어로 분리
- ✨ feat: Enable reactivation of deactivated members upon login
: 회원 탈퇴 후 기간 내 로그인 시 자동 복구 기능 구현
---
# 🔥 추가 작업
> 생성된 채팅방 목록 조회 API를 구현하였습니다.

### 스크린샷
### `[회원탈퇴]`

<img width="1551" height="728" alt="스크린샷 2025-11-08 182510" src="https://github.com/user-attachments/assets/7c0237ef-abfd-49a4-8a78-097518f2a656" />

---

### `[채팅목록 조회]`

<img width="851" height="805" alt="image" src="https://github.com/user-attachments/assets/daa5cf19-57f9-4e53-af15-c5e92c544408" />


## 💬리뷰 요구사항(선택)
- 탈퇴 시 재 로그인 시 자동 복구 되는 기간은 7일로 잡았습니다. -> 관련해서 더 늘리거나 줄이고 싶은 의견 있으시면 말씀해주세요
- 현재 테스트는 기간이 일주일 뒤라 따로 테스트 하지는 못하고 단순 탈퇴만 테스트 하였습니다.

- 현재 채팅방 목록 조회하는 api개발 브랜치로 이동했어야했는데 깜빡하고 이동안하고 하여 올린점 양해 부탁드립니다.

**체크리스트**

- [x] API 테스트를 통과했나요?
- [x] API 문서화 도구(Swagger)를 적용했나요?
- [x] 산출물 업데이트가 필요한 경우 반영했나요?
- [x] 관련 브랜치 전략 및 머지 대상이 적절하나요?
- [x] 주요 로직에 적절한 로그/주석이 포함되었나요?
- [x] 코드 컨벤션을 준수했나요? (파일명, 네이밍, 포맷 등)
