### PR TITLE
Oauth2.0 회원가입 및 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     // WebSocket 추가
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
 

--- a/src/main/java/com/bookbook/booklink/common/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/bookbook/booklink/common/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.bookbook.booklink.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/com/bookbook/booklink/common/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/bookbook/booklink/common/oauth/CustomOAuth2User.java
@@ -1,0 +1,38 @@
+package com.bookbook.booklink.common.oauth;
+
+import com.bookbook.booklink.auth_service.model.Member;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+    private final Member member;
+    private final Map<String, Object> attributes;
+
+    public CustomOAuth2User(Member member, Map<String, Object> attributes) {
+        this.member = member;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(member.getRole().name()));
+    }
+
+    @Override
+    public String getName() {
+        return member.getEmail();
+    }
+}

--- a/src/main/java/com/bookbook/booklink/common/oauth/KakaoOAuth2UserService.java
+++ b/src/main/java/com/bookbook/booklink/common/oauth/KakaoOAuth2UserService.java
@@ -1,0 +1,57 @@
+package com.bookbook.booklink.common.oauth;
+
+import com.bookbook.booklink.auth_service.code.Provider;
+import com.bookbook.booklink.auth_service.code.Role;
+import com.bookbook.booklink.auth_service.code.Status;
+import com.bookbook.booklink.auth_service.model.Member;
+import com.bookbook.booklink.auth_service.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest)
+            throws OAuth2AuthenticationException {
+
+        OAuth2User oauth2User = super.loadUser(userRequest);
+
+        Map<String, Object> attributes = oauth2User.getAttributes();
+        Map<String, Object> kakaoAccount =
+                (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile =
+                (Map<String, Object>) kakaoAccount.get("profile");
+
+        String email = (String) kakaoAccount.get("email");
+        String nickname = (String) profile.get("nickname");
+        String dummyPassword = passwordEncoder.encode("OAUTH_KAKAO_" + email);
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseGet(() -> memberRepository.save(
+                        Member.builder()
+                                .email(email)
+                                .password(dummyPassword)
+                                .role(Role.CUSTOMER)
+                                .name(nickname)
+                                .nickname(nickname)
+                                .provider(Provider.KAKAO)
+                                .status(Status.ACTIVE)
+                                .build()
+                ));
+        // 이로직 이후에 따로 회원정보를 담아야하나? nickname이라던가 update api 하면 되나?
+
+        return new CustomOAuth2User(member, attributes);
+    }
+}

--- a/src/main/java/com/bookbook/booklink/common/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/bookbook/booklink/common/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,53 @@
+package com.bookbook.booklink.common.oauth;
+
+import com.bookbook.booklink.common.jwt.service.RefreshTokenService;
+import com.bookbook.booklink.common.jwt.util.JWTUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication) throws IOException {
+
+        CustomOAuth2User oauthUser =
+                (CustomOAuth2User) authentication.getPrincipal();
+
+        String email = oauthUser.getMember().getEmail();
+        String role = oauthUser.getMember().getRole().name();
+
+        String accessToken = jwtUtil.createAccessToken(email, role);
+        String refreshToken = jwtUtil.createRefreshToken(email);
+
+        refreshTokenService.saveRefreshToken(email, refreshToken);
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .sameSite("Strict")
+                .maxAge(60 * 60 * 24 * 7)
+                .build();
+
+        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        response.sendRedirect(
+                "http://localhost:3000/oauth/callback?accessToken=" + accessToken
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,28 @@ spring:
       repositories:
         enabled: false
 
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${CLIENT_ID}
+            client-secret: ${CLIENT_SECRET}
+            redirect-uri: ${REDIRECT_URI}
+            client-authentication-method: post
+            authorization-grant-type: authorization_code
+            scope:
+            - profile_nickname
+            - profile_image
+            client-name: Kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+
   cloud:
     aws:
       s3:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,11 +34,12 @@ spring:
             client-id: ${CLIENT_ID}
             client-secret: ${CLIENT_SECRET}
             redirect-uri: ${REDIRECT_URI}
-            client-authentication-method: post
+            client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             scope:
             - profile_nickname
             - profile_image
+            - account_email
             client-name: Kakao
         provider:
           kakao:


### PR DESCRIPTION
## 📝작업 내용
Oauth2.0 회원가입 및 로그인 구현하였습니다.

### 스크린샷

## 🔗 참고 자료
---
<img width="1266" height="107" alt="스크린샷 2025-12-14 001120" src="https://github.com/user-attachments/assets/8813feb9-e662-4c56-ac28-7ad99493dab3" />
---
<img width="1418" height="946" alt="스크린샷 2025-12-14 001044" src="https://github.com/user-attachments/assets/e6410188-243c-4929-ac8b-82204b954b12" />
---
## 💬리뷰 요구사항(선택)
- yml에 환경변수 추가 되어 노션에 공유했습니다.
- 회원가입 이후 AcceesToken이 담긴 url이나오는데 해당 url을 프론트에서 처리하면 될것같습니다.

**체크리스트**

- [x] API 테스트를 통과했나요?
- [x] API 문서화 도구(Swagger)를 적용했나요?
- [x] 산출물 업데이트가 필요한 경우 반영했나요?
- [x] 관련 브랜치 전략 및 머지 대상이 적절하나요?
- [x] 주요 로직에 적절한 로그/주석이 포함되었나요?
- [x] 코드 컨벤션을 준수했나요? (파일명, 네이밍, 포맷 등)
